### PR TITLE
Change target framework to .NET Standard 1.3?

### DIFF
--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <Description>.NET Core class library for using PGP</Description>
     <Authors>mattosaurus</Authors>
     <Company />

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <Description>.NET Core class library for using PGP</Description>
+    <Description>.NET Standard class library for using PGP</Description>
     <Authors>mattosaurus</Authors>
     <Company />
     <Product>PgpCore</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
-    <PackageTags>PGP .NET Core</PackageTags>
+    <PackageTags>PGP .NET Core Standard</PackageTags>
     <Version>1.1.0</Version>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>


### PR DESCRIPTION
Hi, great work! 

What do you think about changing the target framework to .NET Standard 1.3 to improve compatability?
The only dependency BouncyCastle.NetCore targets .NET Standard 1.3.

My use case is Azure Functions which did not work with a .NET Core library but im sure there are others as well. 

I have done some testing with a console app and an Azure Function and everything seems to be working fine.