### PR TITLE
Moved ReadPublicKey to Utilities

### DIFF
--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -43,7 +43,7 @@ namespace PgpCore
             if (!File.Exists(privateKeyFilePath))
                 throw new FileNotFoundException(String.Format("Private Key file [{0}] does not exist.", privateKeyFilePath));
 
-            PublicKey = ReadPublicKey(publicKeyFilePath);
+            PublicKey = Utilities.ReadPublicKey(publicKeyFilePath);
             SecretKey = ReadSecretKey(privateKeyFilePath);
             PrivateKey = ReadPrivateKey(passPhrase);
         }
@@ -57,7 +57,7 @@ namespace PgpCore
             if (passPhrase == null)
                 throw new ArgumentNullException("Invalid Pass Phrase.");
 
-            PublicKey = ReadPublicKey(publicKeyStream);
+            PublicKey = Utilities.ReadPublicKey(publicKeyStream);
             SecretKey = ReadSecretKey(privateKeyStream);
             PrivateKey = ReadPrivateKey(passPhrase);
         }
@@ -114,34 +114,7 @@ namespace PgpCore
         #endregion Secret Key
 
         #region Public Key
-
-        private PgpPublicKey ReadPublicKey(string publicKeyPath)
-        {
-            using (Stream keyIn = File.OpenRead(publicKeyPath))
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(keyIn))
-                {
-                    PgpPublicKeyRingBundle publicKeyRingBundle = new PgpPublicKeyRingBundle(inputStream);
-                    PgpPublicKey foundKey = GetFirstPublicKey(publicKeyRingBundle);
-                    if (foundKey != null)
-                        return foundKey;
-                }
-            }
-            throw new ArgumentException("No encryption key found in public key ring.");
-        }
-
-        private PgpPublicKey ReadPublicKey(Stream publicKeyStream)
-        {
-            using (Stream inputStream = PgpUtilities.GetDecoderStream(publicKeyStream))
-            {
-                PgpPublicKeyRingBundle publicKeyRingBundle = new PgpPublicKeyRingBundle(inputStream);
-                PgpPublicKey foundKey = GetFirstPublicKey(publicKeyRingBundle);
-                if (foundKey != null)
-                    return foundKey;
-            }
-            throw new ArgumentException("No encryption key found in public key ring.");
-        }
-
+       
         private PgpPublicKey GetFirstPublicKey(PgpPublicKeyRingBundle publicKeyRingBundle)
         {
             foreach (PgpPublicKeyRing kRing in publicKeyRingBundle.GetKeyRings())

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -151,7 +151,7 @@ namespace PgpCore
                 {
                     using (Stream pkStream = File.OpenRead(publicKeyFilePath))
                     {
-                        pk.AddMethod(ReadPublicKey(pkStream));
+                        pk.AddMethod(Utilities.ReadPublicKey(pkStream));
                     }
                 }
 
@@ -210,7 +210,7 @@ namespace PgpCore
                     Utilities.WriteStreamToLiteralData(@out, FileTypeToChar(), inputStream, "name");
 
                 PgpEncryptedDataGenerator pk = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-                pk.AddMethod(ReadPublicKey(publicKeyStream));
+                pk.AddMethod(Utilities.ReadPublicKey(publicKeyStream));
 
                 byte[] bytes = @out.ToArray();
 
@@ -720,31 +720,7 @@ namespace PgpCore
 
             publicOut.Dispose();
         }
-
-        /*
-        * A simple routine that opens a key ring file and loads the first available key suitable for encryption.
-        */
-        private PgpPublicKey ReadPublicKey(Stream inputStream)
-        {
-            inputStream = PgpUtilities.GetDecoderStream(inputStream);
-
-            PgpPublicKeyRingBundle pgpPub = new PgpPublicKeyRingBundle(inputStream);
-
-            // we just loop through the collection till we find a key suitable for encryption, in the real
-            // world you would probably want to be a bit smarter about this.
-            // iterate through the key rings.
-            foreach (PgpPublicKeyRing kRing in pgpPub.GetKeyRings())
-            {
-                foreach (PgpPublicKey k in kRing.GetPublicKeys())
-                {
-                    if (k.IsEncryptionKey)
-                        return k;
-                }
-            }
-
-            throw new ArgumentException("Can't find encryption key in key ring.");
-        }
-
+        
         /*
         * Search a secret key ring collection for a secret key corresponding to keyId if it exists.
         */

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -10,10 +10,10 @@
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
     <PackageTags>PGP .NET Core</PackageTags>
-    <Version>1.2.1</Version>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
-    <PackageReleaseNotes>Added EncryptStreamAndSignAsync.</PackageReleaseNotes>
+    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
+    <PackageReleaseNotes>Allow encryption with multiple keys</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- changed ReadPublicKey to public, since it my be useful to use it elsewhere. ( I personally need it 👍 )
- moving ReadPublicKey to Utilities reduced redundancy since it was declared multiple times.