### PR TITLE
DecryptAndVerify fixes

### DIFF
--- a/PgpCore.Tests/UnitTests.cs
+++ b/PgpCore.Tests/UnitTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using Xunit;
 
 namespace PgpCore.Tests
@@ -246,6 +247,34 @@ namespace PgpCore.Tests
             // Teardown
             Teardown();
         }
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public void DecryptFileAndVerify_DecryptEncryptedFile(KeyType keyType)
+        {
+            // Arrange
+            Arrange(keyType);
+            PGP pgp = new PGP();
+
+            // Act
+            pgp.EncryptFile(contentFilePath, encryptedContentFilePath, publicKeyFilePath2);
+            var ex = Assert.Throws<PgpException>(() => pgp.DecryptFileAndVerify(encryptedContentFilePath,
+                decryptedContentFilePath1, publicKeyFilePath1, privateKeyFilePath2, password2));
+           
+            
+            string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
+
+            // Assert
+            Assert.Equal("Failed to verify file.", ex.Message);
+            Assert.True(File.Exists(encryptedContentFilePath));
+            Assert.True(File.Exists(decryptedContentFilePath1));
+            Assert.Equal(string.Empty, decryptedContent.Trim());
+
+            // Teardown
+            Teardown();
+        }
 
         [Theory]
         [InlineData(KeyType.Generated)]
@@ -260,6 +289,30 @@ namespace PgpCore.Tests
             // Act
             pgp.EncryptFileAndSign(contentFilePath, encryptedContentFilePath, publicKeyFilePath1, privateKeyFilePath1, password1);
             pgp.DecryptFileAndVerify(encryptedContentFilePath, decryptedContentFilePath1, publicKeyFilePath1, privateKeyFilePath1, password1);
+            string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
+
+            // Assert
+            Assert.True(File.Exists(encryptedContentFilePath));
+            Assert.True(File.Exists(decryptedContentFilePath1));
+            Assert.Equal(content, decryptedContent.Trim());
+
+            // Teardown
+            Teardown();
+        }
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public void DecryptFileAndVerify_DecryptSignedAndEncryptedFileDifferentKeys(KeyType keyType)
+        {
+            // Arrange
+            Arrange(keyType);
+            PGP pgp = new PGP();
+
+            // Act
+            pgp.EncryptFileAndSign(contentFilePath, encryptedContentFilePath, publicKeyFilePath2, privateKeyFilePath1, password1);
+            pgp.DecryptFileAndVerify(encryptedContentFilePath, decryptedContentFilePath1, publicKeyFilePath1, privateKeyFilePath2, password2);
             string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
 
             // Assert

--- a/PgpCore.Tests/UnitTests.cs
+++ b/PgpCore.Tests/UnitTests.cs
@@ -252,7 +252,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
-        public void DecryptFileAndVerify_DecryptEncryptedFile(KeyType keyType)
+        public void DecryptFileAndVerify_DecryptUnsignedFile(KeyType keyType)
         {
             // Arrange
             Arrange(keyType);
@@ -263,7 +263,34 @@ namespace PgpCore.Tests
             var ex = Assert.Throws<PgpException>(() => pgp.DecryptFileAndVerify(encryptedContentFilePath,
                 decryptedContentFilePath1, publicKeyFilePath1, privateKeyFilePath2, password2));
            
-            
+            string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
+
+            // Assert
+            Assert.Equal("File was not signed.", ex.Message);
+            Assert.True(File.Exists(encryptedContentFilePath));
+            Assert.True(File.Exists(decryptedContentFilePath1));
+            Assert.Equal(string.Empty, decryptedContent.Trim());
+
+            // Teardown
+            Teardown();
+        }
+
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public void DecryptFileAndVerify_DecryptWithWrongKey(KeyType keyType)
+        {
+            // Arrange
+            Arrange(keyType);
+            PGP pgp = new PGP();
+
+            // Act
+            pgp.EncryptFileAndSign(contentFilePath, encryptedContentFilePath, publicKeyFilePath1, privateKeyFilePath1, password1);
+            var ex = Assert.Throws<PgpException>(() => pgp.DecryptFileAndVerify(encryptedContentFilePath,
+                decryptedContentFilePath1, publicKeyFilePath2, privateKeyFilePath1, password1));
+           
             string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
 
             // Assert
@@ -275,7 +302,7 @@ namespace PgpCore.Tests
             // Teardown
             Teardown();
         }
-
+        
         [Theory]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]

--- a/PgpCore.Tests/UnitTests.cs
+++ b/PgpCore.Tests/UnitTests.cs
@@ -251,6 +251,30 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public void DecryptFileAndVerify_DecryptSignedAndEncryptedFile(KeyType keyType)
+        {
+            // Arrange
+            Arrange(keyType);
+            PGP pgp = new PGP();
+
+            // Act
+            pgp.EncryptFileAndSign(contentFilePath, encryptedContentFilePath, publicKeyFilePath1, privateKeyFilePath1, password1);
+            pgp.DecryptFileAndVerify(encryptedContentFilePath, decryptedContentFilePath1, publicKeyFilePath1, privateKeyFilePath1, password1);
+            string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
+
+            // Assert
+            Assert.True(File.Exists(encryptedContentFilePath));
+            Assert.True(File.Exists(decryptedContentFilePath1));
+            Assert.Equal(content, decryptedContent.Trim());
+
+            // Teardown
+            Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public void Verify_VerifyEncryptedAndSignedFile(KeyType keyType)
         {
             // Arrange


### PR DESCRIPTION
Hey, great library btw.

I was trying to use `pgp.DecryptAndVerify()` and was receiving the error `invalid header encountered`. 

I wrote the test to see if it was something I was doing wrong and got the same error.

- Noticed that in other places a decoded stream is passed to ExtractPublicKeyEncryptedData.
- The message is already decrypted in the helper methods.
