### PR TITLE
Open keys and input files with read-only access

### DIFF
--- a/PgpCore.Tests/PgpCore.Tests.csproj
+++ b/PgpCore.Tests/PgpCore.Tests.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\PgpCore\PgpCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
@@ -24,6 +24,9 @@ namespace PgpCore.Tests
             // Assert
             Assert.True(File.Exists(publicKeyFilePath1));
             Assert.True(File.Exists(privateKeyFilePath1));
+            
+            //Cleanup
+            Directory.Delete(keyDirectory, true);
         }
 
         #region File
@@ -515,9 +518,9 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAsync(inputFileStream, outputFileStream, publicKeyStream);
 
             // Assert
@@ -538,9 +541,9 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.SignStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             // Assert
@@ -561,10 +564,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAsync(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
             // Assert
@@ -585,10 +588,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAndSignAsync(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             // Assert
@@ -609,11 +612,11 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAndSignAsync(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 }, privateKeyStream, password1);
 
             // Assert
@@ -634,14 +637,14 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAsync(inputFileStream, outputFileStream, publicKeyStream);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             string decryptedContent = await File.ReadAllTextAsync(decryptedContentFilePath1);
@@ -666,20 +669,20 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAsync(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath2))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password2);
 
             string decryptedContent1 = await File.ReadAllTextAsync(decryptedContentFilePath1);
@@ -707,15 +710,15 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAndSignAsync(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             string decryptedContent = await File.ReadAllTextAsync(decryptedContentFilePath1);
@@ -743,20 +746,20 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAsync(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath2))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open, FileAccess.Read))
                 await pgp.DecryptStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password2);
 
             string decryptedContent1 = await File.ReadAllTextAsync(decryptedContentFilePath1);
@@ -787,10 +790,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAndSignAsync(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             bool verified = await pgp.VerifyFileAsync(encryptedContentFilePath, publicKeyFilePath1);
@@ -814,10 +817,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.EncryptStreamAndSignAsync(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             bool verified = await pgp.VerifyFileAsync(encryptedContentFilePath, publicKeyFilePath2);
@@ -842,13 +845,13 @@ namespace PgpCore.Tests
             bool verified = false;
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(signedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.SignStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 verified = await pgp.VerifyStreamAsync(inputFileStream, publicKeyStream);
 
             // Assert
@@ -871,13 +874,13 @@ namespace PgpCore.Tests
             bool verified = false;
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(signedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 await pgp.SignStreamAsync(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 verified = await pgp.VerifyStreamAsync(inputFileStream, publicKeyStream);
 
             // Assert
@@ -945,6 +948,10 @@ namespace PgpCore.Tests
                     streamWriter.WriteLine(privateGpgKey2);
                 }
             }
+            File.SetAttributes(publicKeyFilePath1, FileAttributes.ReadOnly);
+            File.SetAttributes(publicKeyFilePath2, FileAttributes.ReadOnly);
+            File.SetAttributes(privateKeyFilePath1, FileAttributes.ReadOnly);
+            File.SetAttributes(privateKeyFilePath2, FileAttributes.ReadOnly);
 
             // Create content file
             if (fileType == FileType.Known)
@@ -958,6 +965,7 @@ namespace PgpCore.Tests
             {
                 await CreateRandomFileAsync(contentFilePath, 7000);
             }
+            File.SetAttributes(contentFilePath, FileAttributes.ReadOnly);
         }
 
         private async Task CreateRandomFileAsync(string filePath, int sizeInMb)
@@ -986,21 +994,25 @@ namespace PgpCore.Tests
             // Remove keys
             if (File.Exists(publicKeyFilePath1))
             {
+                File.SetAttributes(publicKeyFilePath1, FileAttributes.Normal);
                 File.Delete(publicKeyFilePath1);
             }
 
             if (File.Exists(privateKeyFilePath1))
             {
+                File.SetAttributes(privateKeyFilePath1, FileAttributes.Normal);
                 File.Delete(privateKeyFilePath1);
             }
 
             if (File.Exists(publicKeyFilePath2))
             {
+                File.SetAttributes(publicKeyFilePath2, FileAttributes.Normal);
                 File.Delete(publicKeyFilePath2);
             }
 
             if (File.Exists(privateKeyFilePath2))
             {
+                File.SetAttributes(privateKeyFilePath2, FileAttributes.Normal);
                 File.Delete(privateKeyFilePath2);
             }
 
@@ -1012,6 +1024,7 @@ namespace PgpCore.Tests
             // Remove content
             if (File.Exists(contentFilePath))
             {
+                File.SetAttributes(contentFilePath, FileAttributes.Normal);
                 File.Delete(contentFilePath);
             }
 

--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -23,6 +23,9 @@ namespace PgpCore.Tests
             // Assert
             Assert.True(File.Exists(publicKeyFilePath1));
             Assert.True(File.Exists(privateKeyFilePath1));
+            
+            //Cleanup
+            Directory.Delete(keyDirectory, true);
         }
 
         #region File
@@ -514,9 +517,9 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStream(inputFileStream, outputFileStream, publicKeyStream);
 
             // Assert
@@ -537,9 +540,9 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.SignStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             // Assert
@@ -560,10 +563,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStream(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
             // Assert
@@ -584,10 +587,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStreamAndSign(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             // Assert
@@ -608,11 +611,11 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStreamAndSign(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 }, privateKeyStream, password1);
 
             // Assert
@@ -633,14 +636,14 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStream(inputFileStream, outputFileStream, publicKeyStream);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
@@ -665,20 +668,20 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStream(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath2))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password2);
 
             string decryptedContent1 = File.ReadAllText(decryptedContentFilePath1);
@@ -706,15 +709,15 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStreamAndSign(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
             string decryptedContent = File.ReadAllText(decryptedContentFilePath1);
@@ -742,20 +745,20 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (Stream publicKeyStream1 = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream2 = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStream(inputFileStream, outputFileStream, new List<Stream>() { publicKeyStream1, publicKeyStream2 });
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath1))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(encryptedContentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(decryptedContentFilePath2))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath2, FileMode.Open, FileAccess.Read))
                 pgp.DecryptStream(inputFileStream, outputFileStream, privateKeyStream, password2);
 
             string decryptedContent1 = File.ReadAllText(decryptedContentFilePath1);
@@ -786,10 +789,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStreamAndSign(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             bool verified = pgp.VerifyFile(encryptedContentFilePath, publicKeyFilePath1);
@@ -813,10 +816,10 @@ namespace PgpCore.Tests
             PGP pgp = new PGP();
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(encryptedContentFilePath))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.EncryptStreamAndSign(inputFileStream, outputFileStream, publicKeyStream, privateKeyStream, password1);
 
             bool verified = pgp.VerifyFile(encryptedContentFilePath, publicKeyFilePath2);
@@ -841,13 +844,13 @@ namespace PgpCore.Tests
             bool verified = false;
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(signedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.SignStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath1, FileMode.Open, FileAccess.Read))
                 verified = pgp.VerifyStream(inputFileStream, publicKeyStream);
 
             // Assert
@@ -870,13 +873,13 @@ namespace PgpCore.Tests
             bool verified = false;
 
             // Act
-            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(contentFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputFileStream = File.Create(signedContentFilePath))
-            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open))
+            using (Stream privateKeyStream = new FileStream(privateKeyFilePath1, FileMode.Open, FileAccess.Read))
                 pgp.SignStream(inputFileStream, outputFileStream, privateKeyStream, password1);
 
-            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open))
-            using (Stream publicKeyStream = new FileStream(publicKeyFilePath2, FileMode.Open))
+            using (FileStream inputFileStream = new FileStream(signedContentFilePath, FileMode.Open, FileAccess.Read))
+            using (Stream publicKeyStream = new FileStream(publicKeyFilePath2, FileMode.Open, FileAccess.Read))
                 verified = pgp.VerifyStream(inputFileStream, publicKeyStream);
 
             // Assert
@@ -944,6 +947,10 @@ namespace PgpCore.Tests
                     streamWriter.WriteLine(privateGpgKey2);
                 }
             }
+            File.SetAttributes(publicKeyFilePath1, FileAttributes.ReadOnly);
+            File.SetAttributes(publicKeyFilePath2, FileAttributes.ReadOnly);
+            File.SetAttributes(privateKeyFilePath1, FileAttributes.ReadOnly);
+            File.SetAttributes(privateKeyFilePath2, FileAttributes.ReadOnly);
 
             // Create content file
             if (fileType == FileType.Known)
@@ -957,6 +964,7 @@ namespace PgpCore.Tests
             {
                 CreateRandomFile(contentFilePath, 7000);
             }
+            File.SetAttributes(contentFilePath, FileAttributes.ReadOnly);
         }
 
         private void CreateRandomFile(string filePath, int sizeInMb)
@@ -985,21 +993,25 @@ namespace PgpCore.Tests
             // Remove keys
             if (File.Exists(publicKeyFilePath1))
             {
+                File.SetAttributes(publicKeyFilePath1, FileAttributes.Normal);
                 File.Delete(publicKeyFilePath1);
             }
 
             if (File.Exists(privateKeyFilePath1))
             {
+                File.SetAttributes(privateKeyFilePath1, FileAttributes.Normal);
                 File.Delete(privateKeyFilePath1);
             }
 
             if (File.Exists(publicKeyFilePath2))
             {
+                File.SetAttributes(publicKeyFilePath2, FileAttributes.Normal);
                 File.Delete(publicKeyFilePath2);
             }
 
             if (File.Exists(privateKeyFilePath2))
             {
+                File.SetAttributes(privateKeyFilePath2, FileAttributes.Normal);
                 File.Delete(privateKeyFilePath2);
             }
 
@@ -1011,6 +1023,7 @@ namespace PgpCore.Tests
             // Remove content
             if (File.Exists(contentFilePath))
             {
+                File.SetAttributes(contentFilePath, FileAttributes.Normal);
                 File.Delete(contentFilePath);
             }
 

--- a/PgpCore.Tests/xunit.runner.json
+++ b/PgpCore.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "parallelizeTestCollections": false
+}

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -158,7 +158,7 @@ namespace PgpCore
             foreach (string publicKeyFilePath in publicKeyFilePaths)
             {
                 MemoryStream memoryStream = new MemoryStream();
-                using (Stream publicKeyStream = new FileStream(publicKeyFilePath, FileMode.Open))
+                using (Stream publicKeyStream = new FileStream(publicKeyFilePath, FileMode.Open, FileAccess.Read))
                 {
                     await publicKeyStream.CopyToAsync(memoryStream);
                     memoryStream.Position = 0;
@@ -166,7 +166,7 @@ namespace PgpCore
                 }
             }
 
-            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open))
+            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputStream = File.Create(outputFilePath))
                 await EncryptStreamAsync(inputStream, outputStream, publicKeyStreams, armor, withIntegrityCheck, name);
         }
@@ -210,7 +210,7 @@ namespace PgpCore
             foreach (string publicKeyFilePath in publicKeyFilePaths)
             {
                 MemoryStream memoryStream = new MemoryStream();
-                using (Stream publicKeyStream = new FileStream(publicKeyFilePath, FileMode.Open))
+                using (Stream publicKeyStream = new FileStream(publicKeyFilePath, FileMode.Open, FileAccess.Read))
                 {
                     publicKeyStream.CopyTo(memoryStream);
                     memoryStream.Position = 0;
@@ -218,7 +218,7 @@ namespace PgpCore
                 }
             }
 
-            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open))
+            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
             using (Stream outputStream = File.Create(outputFilePath))
                 EncryptStream(inputStream, outputStream, publicKeyStreams, armor, withIntegrityCheck, name);
         }

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -10,12 +10,11 @@
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
     <PackageTags>PGP .NET Core</PackageTags>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
-    <PackageReleaseNotes>v2.2.0 - Allow message name to be set, make sync methods properly sync, improve parameter documentation.</PackageReleaseNotes>
+    <FileVersion>2.2.1.0</FileVersion>
+    <PackageReleaseNotes>v2.2.1 - Handle read-only keys and input files.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>PgpCoreKey.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
   </PropertyGroup>

--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -436,7 +436,7 @@ namespace PgpCore
         {
             if(!File.Exists(publicKeyFilePath))
                 throw new FileNotFoundException(String.Format("File {0} was not found", publicKeyFilePath));
-            using (FileStream fs = new FileStream(publicKeyFilePath, FileMode.Open))
+            using (FileStream fs = new FileStream(publicKeyFilePath, FileMode.Open, FileAccess.Read))
                 return ReadPublicKey(fs);
         }
 


### PR DESCRIPTION
I ran into an issue trying to encrypt a file using a key file that was on a read-only file system. This fixes that issue.