### PR TITLE
Expose ReadPublicKey from stream as public

### DIFF
--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -10,10 +10,10 @@
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
     <PackageTags>PGP .NET Core</PackageTags>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
-    <PackageReleaseNotes>v2.4.0 - Add ability to clear sign and verify such files.</PackageReleaseNotes>
+    <FileVersion>2.4.1.0</FileVersion>
+    <PackageReleaseNotes>v2.4.1 - Add ability to clear sign and verify such files.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <AssemblyOriginatorKeyFile>PgpCoreKey.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -399,7 +399,7 @@ namespace PgpCore
         /// </summary>
         /// <param name="inputStream"></param>
         /// <returns></returns>
-        internal static PgpPublicKey ReadPublicKey(Stream inputStream)
+        public static PgpPublicKey ReadPublicKey(Stream inputStream)
         {
             inputStream = PgpUtilities.GetDecoderStream(inputStream);
 


### PR DESCRIPTION
To allow use of this utility method for public keys not in a file (i.e. from a secrets manager)