### PR TITLE
Avoid NullPointerException

### DIFF
--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -428,7 +428,7 @@ namespace PgpCore
                 {
                     foreach (PgpSignature s in key.GetSignatures())
                     {
-                        if (s.GetHashedSubPackets().GetKeyFlags() == encryptKeyFlags)
+                        if (s.HasSubpackets && s.GetHashedSubPackets().GetKeyFlags() == encryptKeyFlags)
                             return key;
                     }
                 }


### PR DESCRIPTION
When `s.GetHashedSubPackets()` is null the NullPointerException is thrown in line 431