### PR TITLE
Refactored to allow Encryption keys to be supplied In-Memory #65

### DIFF
--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace PgpCore
 {
-    internal sealed class EncryptionKeys
+    public class EncryptionKeys : IEncryptionKeys
     {
         #region Instance Members (Public)
 

--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -16,8 +17,14 @@ namespace PgpCore
         public IEnumerable<PgpPublicKey> PublicKeys { get; private set; }
         public PgpPrivateKey PrivateKey { get; private set; }
         public PgpSecretKey SecretKey { get; private set; }
+        public PgpSecretKeyRingBundle SecretKeys { get; private set; }
 
         #endregion Instance Members (Public)
+
+        #region Instance Members (Private)
+        private readonly string _passPhrase;
+
+        #endregion Instance Members (Private)
 
         #region Constructors
 
@@ -47,6 +54,7 @@ namespace PgpCore
             PublicKey = Utilities.ReadPublicKey(publicKeyFilePath);
             SecretKey = ReadSecretKey(privateKeyFilePath);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
         }
 
         /// <summary>
@@ -82,6 +90,7 @@ namespace PgpCore
             PublicKeys = publicKeys.Select(x => Utilities.ReadPublicKey(x)).ToList();
             SecretKey = ReadSecretKey(privateKeyFilePath);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
         }
 
         public EncryptionKeys(string privateKeyFilePath, string passPhrase)
@@ -97,6 +106,7 @@ namespace PgpCore
             PublicKeys = null;
             SecretKey = ReadSecretKey(privateKeyFilePath);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
         }
 
         public EncryptionKeys(Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
@@ -111,6 +121,7 @@ namespace PgpCore
             PublicKey = Utilities.ReadPublicKey(publicKeyStream);
             SecretKey = ReadSecretKey(privateKeyStream);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
         }
 
         public EncryptionKeys(Stream privateKeyStream, string passPhrase)
@@ -123,6 +134,7 @@ namespace PgpCore
             PublicKey = null;
             SecretKey = ReadSecretKey(privateKeyStream);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
         }
 
         public EncryptionKeys(IEnumerable<Stream> publicKeyStreams, Stream privateKeyStream, string passPhrase)
@@ -143,23 +155,62 @@ namespace PgpCore
             PublicKeys = publicKeys.Select(x => Utilities.ReadPublicKey(x)).ToList();
             SecretKey = ReadSecretKey(privateKeyStream);
             PrivateKey = ReadPrivateKey(passPhrase);
+            _passPhrase = passPhrase;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the EncryptionKeys class.
+        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+        /// The data is encrypted with the recipients public key and signed with your private key.
+        /// </summary>
+        /// <param name="publicKeyFilePath">The key used to encrypt the data</param>
+        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+        public EncryptionKeys(string publicKeyFilePath)
+        {
+            if (String.IsNullOrEmpty(publicKeyFilePath))
+                throw new ArgumentException("PublicKeyFilePath");
+
+            if (!File.Exists(publicKeyFilePath))
+                throw new FileNotFoundException(String.Format("Public Key file [{0}] does not exist.", publicKeyFilePath));
+
+            PublicKey = Utilities.ReadPublicKey(publicKeyFilePath);
+        }
+
+        public EncryptionKeys(Stream publicKeyStream)
+        {
+            if (publicKeyStream == null)
+                throw new ArgumentException("PublicKeyStream");
+
+            PublicKey = Utilities.ReadPublicKey(publicKeyStream);
         }
 
         #endregion Constructors
+
+        #region Public Methods
+
+        public PgpPrivateKey FindSecretKey(long keyId)
+        {
+            PgpSecretKey pgpSecKey = SecretKeys.GetSecretKey(keyId);
+
+            if (pgpSecKey == null)
+                return null;
+
+            return pgpSecKey.ExtractPrivateKey(_passPhrase.ToCharArray());
+        }
+
+        #endregion Public Methods
 
         #region Secret Key
 
         private PgpSecretKey ReadSecretKey(string privateKeyPath)
         {
             using (Stream sr = File.OpenRead(privateKeyPath))
+            using (Stream inputStream = PgpUtilities.GetDecoderStream(sr))
             {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(sr))
-                {
-                    PgpSecretKeyRingBundle secretKeyRingBundle = new PgpSecretKeyRingBundle(inputStream);
-                    PgpSecretKey foundKey = GetFirstSecretKey(secretKeyRingBundle);
-                    if (foundKey != null)
-                        return foundKey;
-                }
+                SecretKeys = new PgpSecretKeyRingBundle(inputStream);
+                PgpSecretKey foundKey = GetFirstSecretKey(SecretKeys);
+                if (foundKey != null)
+                    return foundKey;
             }
             throw new ArgumentException("Can't find signing key in key ring.");
         }
@@ -168,8 +219,8 @@ namespace PgpCore
         {
             using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyStream))
             {
-                PgpSecretKeyRingBundle secretKeyRingBundle = new PgpSecretKeyRingBundle(inputStream);
-                PgpSecretKey foundKey = GetFirstSecretKey(secretKeyRingBundle);
+                SecretKeys = new PgpSecretKeyRingBundle(inputStream);
+                PgpSecretKey foundKey = GetFirstSecretKey(SecretKeys);
                 if (foundKey != null)
                     return foundKey;
             }

--- a/PgpCore/IEncryptionKeys.cs
+++ b/PgpCore/IEncryptionKeys.cs
@@ -15,5 +15,8 @@ namespace PgpCore
         IEnumerable<PgpPublicKey> PublicKeys { get; }
         PgpPrivateKey PrivateKey { get; }
         PgpSecretKey SecretKey { get; }
+        PgpSecretKeyRingBundle SecretKeys { get; }
+
+        PgpPrivateKey FindSecretKey(long keyId);
     }
 }

--- a/PgpCore/IEncryptionKeys.cs
+++ b/PgpCore/IEncryptionKeys.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Org.BouncyCastle.Bcpg.OpenPgp;
+
+namespace PgpCore
+{
+    /// <summary>
+    /// Encryption Keys
+    /// 
+    /// You can supply any or all of these, however, if PrivateKeys 
+    /// are required Secret keys should also be supplied
+    /// </summary>
+    public interface IEncryptionKeys
+    {
+        PgpPublicKey PublicKey { get; }
+        IEnumerable<PgpPublicKey> PublicKeys { get; }
+        PgpPrivateKey PrivateKey { get; }
+        PgpSecretKey SecretKey { get; }
+    }
+}

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -464,6 +464,29 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            await EncryptFileAndSignAsync(inputFilePath, outputFilePath, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+        public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
+
             if (name == DefaultFileName)
             {
                 name = Path.GetFileName(inputFilePath);
@@ -525,6 +548,29 @@ namespace PgpCore
 
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
+
+            EncryptFileAndSign(inputFilePath, outputFilePath, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+        public void EncryptFileAndSign(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
 
             if (name == DefaultFileName)
             {
@@ -609,7 +655,20 @@ namespace PgpCore
 
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
-                
+
+            await EncryptStreamAndSignAsync(inputStream, outputStream, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+        public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
             if (name == DefaultFileName && inputStream is FileStream)
             {
                 string inputFilePath = ((FileStream)inputStream).Name;
@@ -660,6 +719,27 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            EncryptStreamAndSign(inputStream, outputStream, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+        public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
             if (name == DefaultFileName && inputStream is FileStream)
             {
                 string inputFilePath = ((FileStream)inputStream).Name;
@@ -677,7 +757,7 @@ namespace PgpCore
                 OutputEncrypted(inputStream, outputStream, encryptionKeys, withIntegrityCheck, name);
         }
 
-        private async Task OutputEncryptedAsync(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private async Task OutputEncryptedAsync(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream encryptedOut = ChainEncryptedOut(outputStream, encryptionKeys, withIntegrityCheck))
             {
@@ -697,7 +777,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputEncrypted(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private void OutputEncrypted(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream encryptedOut = ChainEncryptedOut(outputStream, encryptionKeys, withIntegrityCheck))
             {
@@ -717,7 +797,7 @@ namespace PgpCore
             }
         }
 
-        private async Task OutputSignedAsync(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private async Task OutputSignedAsync(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             FileInfo unencryptedFileInfo = new FileInfo(inputFilePath);
             using (Stream compressedOut = ChainCompressedOut(outputStream))
@@ -734,7 +814,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputSigned(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private void OutputSigned(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             FileInfo unencryptedFileInfo = new FileInfo(inputFilePath);
             using (Stream compressedOut = ChainCompressedOut(outputStream))
@@ -751,7 +831,7 @@ namespace PgpCore
             }
         }
 
-        private async Task OutputClearSignedAsync(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys)
+        private async Task OutputClearSignedAsync(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             FileInfo unencryptedFileInfo = new FileInfo(inputFilePath);
             using (FileStream inputFileStream = unencryptedFileInfo.OpenRead())
@@ -760,7 +840,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputClearSigned(string inputFilePath, Stream outputStream, EncryptionKeys encryptionKeys)
+        private void OutputClearSigned(string inputFilePath, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             FileInfo unencryptedFileInfo = new FileInfo(inputFilePath);
             using (FileStream inputFileStream = unencryptedFileInfo.OpenRead())
@@ -769,7 +849,7 @@ namespace PgpCore
             }
         }
 
-        private async Task OutputEncryptedAsync(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private async Task OutputEncryptedAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream encryptedOut = ChainEncryptedOut(outputStream, encryptionKeys, withIntegrityCheck))
             {
@@ -785,7 +865,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputEncrypted(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private void OutputEncrypted(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream encryptedOut = ChainEncryptedOut(outputStream, encryptionKeys, withIntegrityCheck))
             {
@@ -801,7 +881,7 @@ namespace PgpCore
             }
         }
 
-        private async Task OutputSignedAsync(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private async Task OutputSignedAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream compressedOut = ChainCompressedOut(outputStream))
             {
@@ -814,7 +894,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputSigned(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
+        private void OutputSigned(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck, string name)
         {
             using (Stream compressedOut = ChainCompressedOut(outputStream))
             {
@@ -827,7 +907,7 @@ namespace PgpCore
             }
         }
 
-        private async Task OutputClearSignedAsync(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys)
+        private async Task OutputClearSignedAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             using (StreamReader streamReader = new StreamReader(inputStream))
             using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
@@ -865,7 +945,7 @@ namespace PgpCore
             }
         }
 
-        private void OutputClearSigned(Stream inputStream, Stream outputStream, EncryptionKeys encryptionKeys)
+        private void OutputClearSigned(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             using (StreamReader streamReader = new StreamReader(inputStream))
             using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
@@ -951,7 +1031,7 @@ namespace PgpCore
             signatureGenerator.Generate().Encode(compressedOut);
         }
 
-        private Stream ChainEncryptedOut(Stream outputStream, EncryptionKeys encryptionKeys, bool withIntegrityCheck)
+        private Stream ChainEncryptedOut(Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck)
         {
             PgpEncryptedDataGenerator encryptedDataGenerator;
             encryptedDataGenerator = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
@@ -994,7 +1074,7 @@ namespace PgpCore
             return pgpLiteralDataGenerator.Open(compressedOut, FileTypeToChar(), name, inputStream.Length, DateTime.UtcNow);
         }
 
-        private PgpSignatureGenerator InitSignatureGenerator(Stream compressedOut, EncryptionKeys encryptionKeys)
+        private PgpSignatureGenerator InitSignatureGenerator(Stream compressedOut, IEncryptionKeys encryptionKeys)
         {
             PublicKeyAlgorithmTag tag = encryptionKeys.SecretKey.PublicKey.Algorithm;
             PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
@@ -1011,7 +1091,7 @@ namespace PgpCore
             return pgpSignatureGenerator;
         }
 
-        private PgpSignatureGenerator InitClearSignatureGenerator(ArmoredOutputStream armoredOutputStream, EncryptionKeys encryptionKeys)
+        private PgpSignatureGenerator InitClearSignatureGenerator(ArmoredOutputStream armoredOutputStream, IEncryptionKeys encryptionKeys)
         {
             PublicKeyAlgorithmTag tag = encryptionKeys.SecretKey.PublicKey.Algorithm;
             PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
@@ -1063,6 +1143,30 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            await SignFileAsync(inputFilePath, outputFilePath, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Sign the file pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be signed</param>
+        /// <param name="outputFilePath">Output PGP signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
+        public async Task SignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, 
+            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
+
             if (name == DefaultFileName)
             {
                 name = Path.GetFileName(inputFilePath);
@@ -1113,6 +1217,30 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            SignFile(inputFilePath, outputFilePath, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Sign the file pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be signed</param>
+        /// <param name="outputFilePath">Output PGP signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
+        public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, 
+            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
+
             if (name == DefaultFileName)
             {
                 name = Path.GetFileName(inputFilePath);
@@ -1158,6 +1286,27 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            await SignStreamAsync(inputStream, outputStream, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Sign the stream pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be signed</param>
+        /// <param name="outputStream">Output PGP signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
+        public async Task SignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
             if (name == DefaultFileName && inputStream is FileStream)
             {
                 string inputFilePath = ((FileStream)inputStream).Name;
@@ -1198,6 +1347,27 @@ namespace PgpCore
 
             EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
 
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            SignStream(inputStream, outputStream, encryptionKeys, armor, withIntegrityCheck, name);
+        }
+
+        /// <summary>
+        /// Sign the stream pointed to by unencryptedFileInfo and
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be signed</param>
+        /// <param name="outputStream">Output PGP signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
+        public void SignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
@@ -1251,6 +1421,27 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            await ClearSignFileAsync(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// Clear sign the file pointed to by unencryptedFileInfo
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be signed</param>
+        /// <param name="outputFilePath">Output PGP signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
+
             using (Stream outputStream = File.Create(outputFilePath))
             {
                 await OutputClearSignedAsync(inputFilePath, outputStream, encryptionKeys);
@@ -1285,6 +1476,27 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            ClearSignFile(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// Clear sign the file pointed to by unencryptedFileInfo
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be signed</param>
+        /// <param name="outputFilePath">Output PGP signed file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public void ClearSignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
+
             using (Stream outputStream = File.Create(outputFilePath))
             {
                 OutputClearSigned(inputFilePath, outputStream, encryptionKeys);
@@ -1314,6 +1526,24 @@ namespace PgpCore
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 
+            await ClearSignStreamAsync(inputStream, outputStream, encryptionKeys);
+        }
+
+        /// <summary>
+        /// Clear sign the provided stream
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be signed</param>
+        /// <param name="outputStream">Output PGP signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
             await OutputClearSignedAsync(inputStream, outputStream, encryptionKeys);
         }
 
@@ -1337,6 +1567,24 @@ namespace PgpCore
 
             EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
 
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            ClearSignStream(inputStream, outputStream, encryptionKeys);
+        }
+
+        /// <summary>
+        /// Clear sign the provided stream
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be signed</param>
+        /// <param name="outputStream">Output PGP signed stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public void ClearSignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
             if (encryptionKeys == null)
                 throw new ArgumentNullException("Encryption Key not found.");
 

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -1618,14 +1618,36 @@ namespace PgpCore
             if (!File.Exists(privateKeyFilePath))
                 throw new FileNotFoundException(String.Format("Private Key File [{0}] not found.", privateKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyFilePath, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptFileAsync(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP decrypt a given file.
+        /// </summary>
+        /// <param name="inputFilePath">PGP encrypted data file path</param>
+        /// <param name="outputFilePath">Output PGP decrypted file path</param>
+        /// <param name="privateKeyFilePath">PGP secret key file path</param>
+        /// <param name="passPhrase">PGP secret key password</param>
+        public async Task DecryptFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            {
-                using (Stream keyStream = File.OpenRead(privateKeyFilePath))
-                {
-                    using (Stream outStream = File.Create(outputFilePath))
-                        await DecryptAsync(inputStream, outStream, keyStream, passPhrase);
-                }
-            }
+            using (Stream outStream = File.Create(outputFilePath))
+                await DecryptStreamAsync(inputStream, outStream, encryptionKeys);
         }
 
         /// <summary>
@@ -1651,14 +1673,36 @@ namespace PgpCore
             if (!File.Exists(privateKeyFilePath))
                 throw new FileNotFoundException(String.Format("Private Key File [{0}] not found.", privateKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyFilePath, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            DecryptFile(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP decrypt a given file.
+        /// </summary>
+        /// <param name="inputFilePath">PGP encrypted data file path</param>
+        /// <param name="outputFilePath">Output PGP decrypted file path</param>
+        /// <param name="privateKeyFilePath">PGP secret key file path</param>
+        /// <param name="passPhrase">PGP secret key password</param>
+        public void DecryptFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            {
-                using (Stream keyStream = File.OpenRead(privateKeyFilePath))
-                {
-                    using (Stream outStream = File.Create(outputFilePath))
-                        Decrypt(inputStream, outStream, keyStream, passPhrase);
-                }
-            }
+            using (Stream outStream = File.Create(outputFilePath))
+                Decrypt(inputStream, outStream, encryptionKeys);
         }
 
         /// <summary>
@@ -1679,7 +1723,31 @@ namespace PgpCore
             if (passPhrase == null)
                 passPhrase = String.Empty;
 
-            await DecryptAsync(inputStream, outputStream, privateKeyStream, passPhrase);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptStreamAsync(inputStream, outputStream, encryptionKeys);
+            return outputStream;
+        }
+
+        /// <summary>
+        /// PGP decrypt a given stream.
+        /// </summary>
+        /// <param name="inputStream">PGP encrypted data stream</param>
+        /// <param name="outputStream">Output PGP decrypted stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptAsync(inputStream, outputStream, encryptionKeys);
             return outputStream;
         }
 
@@ -1701,27 +1769,45 @@ namespace PgpCore
             if (passPhrase == null)
                 passPhrase = String.Empty;
 
-            Decrypt(inputStream, outputStream, privateKeyStream, passPhrase);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            DecryptStream(inputStream, outputStream, encryptionKeys);
+            return outputStream;
+        }
+
+        /// <summary>
+        /// PGP decrypt a given stream.
+        /// </summary>
+        /// <param name="inputStream">PGP encrypted data stream</param>
+        /// <param name="outputStream">Output PGP decrypted stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public Stream DecryptStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            Decrypt(inputStream, outputStream, encryptionKeys);
             return outputStream;
         }
 
         /*
         * PGP decrypt a given stream.
         */
-        private async Task DecryptAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
+        private async Task DecryptAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             if (inputStream == null)
                 throw new ArgumentException("InputStream");
             if (outputStream == null)
                 throw new ArgumentException("outputStream");
-            if (privateKeyStream == null)
-                throw new ArgumentException("privateKeyStream");
-            if (passPhrase == null)
-                passPhrase = String.Empty;
 
             PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-            // find secret key
-            PgpSecretKeyRingBundle pgpSec = new PgpSecretKeyRingBundle(PgpUtilities.GetDecoderStream(privateKeyStream));
 
             PgpObject obj = null;
             if (objFactory != null)
@@ -1739,7 +1825,7 @@ namespace PgpCore
             PgpPublicKeyEncryptedData pbe = null;
             foreach (PgpPublicKeyEncryptedData pked in enc.GetEncryptedDataObjects())
             {
-                privateKey = FindSecretKey(pgpSec, pked.KeyId, passPhrase.ToCharArray());
+                privateKey = encryptionKeys.FindSecretKey(pked.KeyId);
 
                 if (privateKey != null)
                 {
@@ -1817,20 +1903,14 @@ namespace PgpCore
         /*
         * PGP decrypt a given stream.
         */
-        private void Decrypt(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
+        private void Decrypt(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
             if (inputStream == null)
                 throw new ArgumentException("InputStream");
             if (outputStream == null)
                 throw new ArgumentException("outputStream");
-            if (privateKeyStream == null)
-                throw new ArgumentException("privateKeyStream");
-            if (passPhrase == null)
-                passPhrase = String.Empty;
 
             PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-            // find secret key
-            PgpSecretKeyRingBundle pgpSec = new PgpSecretKeyRingBundle(PgpUtilities.GetDecoderStream(privateKeyStream));
 
             PgpObject obj = null;
             if (objFactory != null)
@@ -1852,7 +1932,7 @@ namespace PgpCore
             PgpPublicKeyEncryptedData pbe = null;
             foreach (PgpPublicKeyEncryptedData pked in enc.GetEncryptedDataObjects())
             {
-                privateKey = FindSecretKey(pgpSec, pked.KeyId, passPhrase.ToCharArray());
+                privateKey = encryptionKeys.FindSecretKey(pked.KeyId);
 
                 if (privateKey != null)
                 {
@@ -1959,13 +2039,33 @@ namespace PgpCore
             if (!File.Exists(privateKeyFilePath))
                 throw new FileNotFoundException(String.Format("Private Key File [{0}] not found.", privateKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath, privateKeyFilePath, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptFileAndVerifyAsync(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP decrypt and verify a given file.
+        /// </summary>
+        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            {
-                using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                using (Stream privateKeyStream = File.OpenRead(privateKeyFilePath))
-                using (Stream outStream = File.Create(outputFilePath))
-                    await DecryptAndVerifyAsync(inputStream, outStream, publicKeyStream, privateKeyStream, passPhrase);
-            }
+            using (Stream outStream = File.Create(outputFilePath))
+                await DecryptStreamAndVerifyAsync(inputStream, outStream, encryptionKeys);
         }
 
         /// <summary>
@@ -1996,13 +2096,33 @@ namespace PgpCore
             if (!File.Exists(privateKeyFilePath))
                 throw new FileNotFoundException(String.Format("Private Key File [{0}] not found.", privateKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath, privateKeyFilePath, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            DecryptFileAndVerify(inputFilePath, outputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP decrypt and verify a given file.
+        /// </summary>
+        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public void DecryptFileAndVerify(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (String.IsNullOrEmpty(outputFilePath))
+                throw new ArgumentException("OutputFilePath");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            {
-                using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                using (Stream privateKeyStream = File.OpenRead(privateKeyFilePath))
-                using (Stream outStream = File.Create(outputFilePath))
-                    DecryptAndVerify(inputStream, outStream, publicKeyStream, privateKeyStream, passPhrase);
-            }
+            using (Stream outStream = File.Create(outputFilePath))
+                DecryptAndVerify(inputStream, outStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2026,7 +2146,33 @@ namespace PgpCore
             if (passPhrase == null)
                 passPhrase = String.Empty;
 
-            await DecryptAndVerifyAsync(inputStream, outputStream, publicKeyStream, privateKeyStream, passPhrase);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptStreamAndVerifyAsync(inputStream, outputStream, encryptionKeys);
+            return outputStream;
+        }
+
+        /// <summary>
+        /// PGP decrypt and verify a given stream.
+        /// </summary>
+        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
+        /// <param name="publicKeyStream">PGP public key stream</param>
+        /// <param name="privateKeyStream">PGP secret key stream</param>
+        /// <param name="passPhrase">PGP secret key password</param>
+        public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            await DecryptAndVerifyAsync(inputStream, outputStream, encryptionKeys);
             return outputStream;
         }
 
@@ -2051,17 +2197,37 @@ namespace PgpCore
             if (passPhrase == null)
                 passPhrase = String.Empty;
 
-            DecryptAndVerify(inputStream, outputStream, publicKeyStream, privateKeyStream, passPhrase);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            DecryptStreamAndVerify(inputStream, outputStream, encryptionKeys);
+            return outputStream;
+        }
+
+        /// <summary>
+        /// PGP decrypt and verify a given stream.
+        /// </summary>
+        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (outputStream == null)
+                throw new ArgumentException("OutputStream");
+
+            DecryptAndVerify(inputStream, outputStream, encryptionKeys);
             return outputStream;
         }
 
         /*
         * PGP decrypt and verify a given stream.
         */
-        private async Task DecryptAndVerifyAsync(Stream inputStream, Stream outputStream, Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
+        private async Task DecryptAndVerifyAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
-            // find secret key
-            PgpSecretKeyRingBundle pgpSec = new PgpSecretKeyRingBundle(PgpUtilities.GetDecoderStream(privateKeyStream));
             PgpEncryptedDataList encryptedDataList = Utilities.GetEncryptedDataList(PgpUtilities.GetDecoderStream(inputStream));
 
             // decrypt
@@ -2069,7 +2235,7 @@ namespace PgpCore
             PgpPublicKeyEncryptedData pbe = null;
             foreach (PgpPublicKeyEncryptedData pked in encryptedDataList.GetEncryptedDataObjects())
             {
-                privateKey = FindSecretKey(pgpSec, pked.KeyId, passPhrase.ToCharArray());
+                privateKey = encryptionKeys.FindSecretKey(pked.KeyId);
 
                 if (privateKey != null)
                 {
@@ -2080,8 +2246,6 @@ namespace PgpCore
 
             if (privateKey == null)
                 throw new ArgumentException("Secret key for message not found.");
-
-            var publicKey = Utilities.ReadPublicKey(publicKeyStream);
 
             PgpObjectFactory plainFact = null;
             using (Stream clear = pbe.GetDataStream(privateKey))
@@ -2105,7 +2269,7 @@ namespace PgpCore
             {
                 PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
 
-                var verified = publicKey.KeyId == pgpOnePassSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+                var verified = encryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || encryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
                 if (verified == false)
                     throw new PgpException("Failed to verify file.");
 
@@ -2134,10 +2298,8 @@ namespace PgpCore
         /*
         * PGP decrypt and verify a given stream.
         */
-        private void DecryptAndVerify(Stream inputStream, Stream outputStream, Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
+        private void DecryptAndVerify(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
         {
-            // find secret key
-            PgpSecretKeyRingBundle pgpSec = new PgpSecretKeyRingBundle(PgpUtilities.GetDecoderStream(privateKeyStream));
             PgpEncryptedDataList encryptedDataList = Utilities.GetEncryptedDataList(PgpUtilities.GetDecoderStream(inputStream));
 
             // decrypt
@@ -2145,7 +2307,7 @@ namespace PgpCore
             PgpPublicKeyEncryptedData pbe = null;
             foreach (PgpPublicKeyEncryptedData pked in encryptedDataList.GetEncryptedDataObjects())
             {
-                privateKey = FindSecretKey(pgpSec, pked.KeyId, passPhrase.ToCharArray());
+                privateKey = encryptionKeys.FindSecretKey(pked.KeyId);
 
                 if (privateKey != null)
                 {
@@ -2156,8 +2318,6 @@ namespace PgpCore
 
             if (privateKey == null)
                 throw new ArgumentException("Secret key for message not found.");
-
-            var publicKey = Utilities.ReadPublicKey(publicKeyStream);
 
             PgpObjectFactory plainFact = null;
             using (Stream clear = pbe.GetDataStream(privateKey))
@@ -2181,7 +2341,7 @@ namespace PgpCore
             {
                 PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
 
-                var verified = publicKey.KeyId == pgpOnePassSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+                var verified = encryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || encryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
                 if (verified == false)
                     throw new PgpException("Failed to verify file.");
 
@@ -2224,9 +2384,29 @@ namespace PgpCore
             if (!File.Exists(publicKeyFilePath))
                 throw new FileNotFoundException(String.Format("Public Key File [{0}] not found.", publicKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyFileAsync(inputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given file.
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be verified</param>
+        /// <param name="publicKeyFilePath">PGP public key file path</param>
+        public async Task<bool> VerifyFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                return await VerifyAsync(inputStream, publicKeyStream);
+                return await VerifyAsync(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2246,9 +2426,28 @@ namespace PgpCore
             if (!File.Exists(publicKeyFilePath))
                 throw new FileNotFoundException(String.Format("Public Key File [{0}] not found.", publicKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath);
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return VerifyFile(inputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given file.
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be verified</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public bool VerifyFile(string inputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                return Verify(inputStream, publicKeyStream);
+                return Verify(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2268,9 +2467,28 @@ namespace PgpCore
             if (!File.Exists(publicKeyFilePath))
                 throw new FileNotFoundException(String.Format("Public Key File [{0}] not found.", publicKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyClearFileAsync(inputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given clear signed file.
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be verified</param>
+        /// <param name="encryptionKeys">Encryption Keys</param>
+        public async Task<bool> VerifyClearFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                return await VerifyClearAsync(inputStream, publicKeyStream);
+                return await VerifyClearAsync(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2290,9 +2508,31 @@ namespace PgpCore
             if (!File.Exists(publicKeyFilePath))
                 throw new FileNotFoundException(String.Format("Public Key File [{0}] not found.", publicKeyFilePath));
 
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyFilePath);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return VerifyClearFile(inputFilePath, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given clear signed file.
+        /// </summary>
+        /// <param name="inputFilePath">Plain data file path to be verified</param>
+        /// <param name="publicKeyFilePath">PGP public key file path</param>
+        public bool VerifyClearFile(string inputFilePath, IEncryptionKeys encryptionKeys)
+        {
+            if (String.IsNullOrEmpty(inputFilePath))
+                throw new ArgumentException("InputFilePath");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            if (!File.Exists(inputFilePath))
+                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
+
             using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream publicKeyStream = File.OpenRead(publicKeyFilePath))
-                return VerifyClear(inputStream, publicKeyStream);
+                return VerifyClear(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2307,7 +2547,27 @@ namespace PgpCore
             if (publicKeyStream == null)
                 throw new ArgumentException("PublicKeyStream");
 
-            return await VerifyAsync(inputStream, publicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyStreamAsync(inputStream, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given stream.
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be verified</param>
+        /// <param name="publicKeyStream">PGP public key stream</param>
+        public async Task<bool> VerifyStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyAsync(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2322,7 +2582,25 @@ namespace PgpCore
             if (publicKeyStream == null)
                 throw new ArgumentException("PublicKeyStream");
 
-            return Verify(inputStream, publicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return Verify(inputStream, encryptionKeys);
+        }
+
+        /// <summary>
+        /// PGP verify a given stream.
+        /// </summary>
+        /// <param name="inputStream">Plain data stream to be verified</param>
+        /// <param name="publicKeyStream">PGP public key stream</param>
+        public bool VerifyStream(Stream inputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+
+            return Verify(inputStream, encryptionKeys);
         }
 
         /// <summary>
@@ -2337,8 +2615,29 @@ namespace PgpCore
             if (publicKeyStream == null)
                 throw new ArgumentException("PublicKeyStream");
 
-            return await VerifyClearAsync(inputStream, publicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyClearStreamAsync(inputStream, encryptionKeys);
         }
+
+        /// <summary>
+        /// PGP verify a given clear signed stream.
+        /// </summary>
+        /// <param name="inputStream">Clear signed data stream to be verified</param>
+        /// <param name="publicKeyStream">PGP public key stream</param>
+        public async Task<bool> VerifyClearStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
+        {
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return await VerifyClearAsync(inputStream, encryptionKeys);
+        }
+
 
         /// <summary>
         /// PGP verify a given clear signed stream.
@@ -2352,12 +2651,32 @@ namespace PgpCore
             if (publicKeyStream == null)
                 throw new ArgumentException("PublicKeyStream");
 
-            return VerifyClear(inputStream, publicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(publicKeyStream);
+
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return VerifyClearStream(inputStream, encryptionKeys);
         }
 
-        private async Task<bool> VerifyAsync(Stream inputStream, Stream publicKeyStream)
+        /// <summary>
+        /// PGP verify a given clear signed stream.
+        /// </summary>
+        /// <param name="inputStream">Clear signed stream to be verified</param>
+        /// <param name="publicKeyStream">PGP public key stream</param>
+        public bool VerifyClearStream(Stream inputStream, IEncryptionKeys encryptionKeys)
         {
-            PgpPublicKey publicKey = Utilities.ReadPublicKey(publicKeyStream);
+            if (inputStream == null)
+                throw new ArgumentException("InputStream");
+            if (encryptionKeys == null)
+                throw new ArgumentNullException("Encryption Key not found.");
+
+            return VerifyClear(inputStream, encryptionKeys);
+        }
+
+        private async Task<bool> VerifyAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
+        {
+            PgpPublicKey publicKey = encryptionKeys.PublicKey;
             bool verified = false;
 
             System.IO.Stream encodedFile = PgpUtilities.GetDecoderStream(inputStream);
@@ -2414,9 +2733,9 @@ namespace PgpCore
             return verified;
         }
 
-        private bool Verify(Stream inputStream, Stream publicKeyStream)
+        private bool Verify(Stream inputStream, IEncryptionKeys encryptionKeys)
         {
-            PgpPublicKey publicKey = Utilities.ReadPublicKey(publicKeyStream);
+            PgpPublicKey publicKey = encryptionKeys.PublicKey;
             bool verified = false;
 
             ArmoredInputStream encodedFile = new ArmoredInputStream(inputStream);
@@ -2474,13 +2793,13 @@ namespace PgpCore
         }
 
         // https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
-        private async Task<bool> VerifyClearAsync(Stream inputStream, Stream publicKeyStream)
+        private async Task<bool> VerifyClearAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
         {
             bool verified = false;
 
             using (MemoryStream outStream = new MemoryStream())
             {
-                var publicKey = Utilities.ReadPublicKey(publicKeyStream);
+                var publicKey = encryptionKeys.PublicKey;
                 PgpSignature pgpSignature;
 
                 using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))
@@ -2546,13 +2865,13 @@ namespace PgpCore
         }
 
         // https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
-        private bool VerifyClear(Stream inputStream, Stream publicKeyStream)
+        private bool VerifyClear(Stream inputStream, IEncryptionKeys encryptionKeys)
         {
             bool verified = false;
 
             using (MemoryStream outStream = new MemoryStream())
             {
-                var publicKey = Utilities.ReadPublicKey(publicKeyStream);
+                var publicKey = encryptionKeys.PublicKey;
                 PgpSignature pgpSignature;
 
                 using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))


### PR DESCRIPTION
This is the first part, getting the ClearSign, Encrypted, etc. using a new interface.

I toyed with the idea of an abstract class, but my feeling is that there will be another method as part of this next phase for getting the right keys when multiple are supplied, so it felt better as an interface.  This also allows implementors to add in things like storing the keys in a database easier.

The only advantage I could see for an abstract class was the having some private helpers, but that seemed like a stretch.