### PR TITLE
Target .NET Standard 2.0 exclusively

### DIFF
--- a/PgpCore.Tests/PgpCore.Tests.csproj
+++ b/PgpCore.Tests/PgpCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
@@ -11,6 +11,17 @@ namespace PgpCore.Tests
 {
     public class UnitTestsAsync
     {
+        private static class File
+        {
+            public static FileStream Create(string path) => System.IO.File.Create(path);
+            public static bool Exists(string path) => System.IO.File.Exists(path);
+#if NETFRAMEWORK
+            public static Task<string> ReadAllTextAsync(string path) => Task.FromResult(System.IO.File.ReadAllText(path));
+#else
+            public static Task<string> ReadAllTextAsync(string path) => System.IO.File.ReadAllTextAsync(path);
+#endif
+        }
+
         [Fact]
         public async Task GenerateKeyAsync_CreatePublicPrivateKeyFiles()
         {

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
-    <Description>.NET Standard and Core class library for using PGP</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>.NET Standard class library for using PGP</Description>
     <Authors>mattosaurus</Authors>
     <Company />
     <Product>PgpCore</Product>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A .NET Core class library for using PGP.
 
-This is based on <a href="https://github.com/Cinchoo/ChoPGP" alt="ChoPGP">ChoPGP</a> but updated to .NET Core framework and to add in a missing utilities class.
+This is based on <a href="https://github.com/Cinchoo/ChoPGP" alt="ChoPGP">ChoPGP</a> but updated to .NET Standard and to add in a missing utilities class.
 
 # Installation
 To use PgpCore in your C# project, you can either download the PgpCore C# .NET libraries directly from the Github repository or, if you have the NuGet package manager installed, you can grab them automatically.
@@ -20,12 +20,10 @@ Add the following namespaces to use the library:
 using PgpCore;
 ```
 # Dependencies
-BouncyCastle.NetCore (>= 1.8.1.3)
-
-Microsoft.NETCore.App (>= 1.1.2)
+* Portable.BouncyCastle (>= 1.8.6.7)
 
 # Usage
-This is intended for usage in .NET Core projects, the latest version that works with .NET Framework is v2.2.0.
+This is intended for usage in projects [targeting .NET Standard 2.0](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 
 ## Methods
 


### PR DESCRIPTION
When a library targets .NET Standard, there is no need to multi target netcoreapp versions that implement  the targeted .NET Standard version. This only makes the NuGet package grow in size without any added benefit.

The reason why you would multi-target is to take advantage of APIs in .NET Core that are not available in .NET Standard. This is not the case for this project where all APIs used are compatible with .NET Standard 2.0 (including the Portable.BouncyCastle dependency).

Also, by targeting .NET Standard 2.0, this makes PgpCore compatible with .NET Framework 4.7.2 and 4.8.

The README has also been updated to reflect that change.