### PR TITLE
Verify signature for compressed files

### DIFF
--- a/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
@@ -509,6 +509,34 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public async Task DecryptFileAndVerifyAsync_DecryptSignedAndEncryptedAndCompressedFile(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            await testFactory.ArrangeAsync(keyType, FileType.Known);
+            PGP pgp = new PGP
+            {
+                CompressionAlgorithm = CompressionAlgorithmTag.Zip,
+            };
+
+            // Act
+            await pgp.EncryptFileAndSignAsync(testFactory.ContentFilePath, testFactory.EncryptedContentFilePath, testFactory.PublicKeyFilePath, testFactory.PrivateKeyFilePath, testFactory.Password);
+            await pgp.DecryptFileAndVerifyAsync(testFactory.EncryptedContentFilePath, testFactory.DecryptedContentFilePath, testFactory.PublicKeyFilePath, testFactory.PrivateKeyFilePath, testFactory.Password);
+            string decryptedContent = await File.ReadAllTextAsync(testFactory.DecryptedContentFilePath);
+
+            // Assert
+            Assert.True(File.Exists(testFactory.EncryptedContentFilePath));
+            Assert.True(File.Exists(testFactory.DecryptedContentFilePath));
+            Assert.Equal(testFactory.Content, decryptedContent.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public async Task DecryptFileAndVerifyAsync_DecryptSignedAndEncryptedFileDifferentKeys(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -502,6 +502,34 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public void DecryptFileAndVerify_DecryptSignedAndEncryptedAndCompressedFile(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            testFactory.Arrange(keyType, FileType.Known);
+            PGP pgp = new PGP
+            {
+                CompressionAlgorithm = CompressionAlgorithmTag.Zip,
+            };
+
+            // Act
+            pgp.EncryptFileAndSign(testFactory.ContentFilePath, testFactory.EncryptedContentFilePath, testFactory.PublicKeyFilePath, testFactory.PrivateKeyFilePath, testFactory.Password);
+            pgp.DecryptFileAndVerify(testFactory.EncryptedContentFilePath, testFactory.DecryptedContentFilePath, testFactory.PublicKeyFilePath, testFactory.PrivateKeyFilePath, testFactory.Password);
+            string decryptedContent = File.ReadAllText(testFactory.DecryptedContentFilePath);
+
+            // Assert
+            Assert.True(File.Exists(testFactory.EncryptedContentFilePath));
+            Assert.True(File.Exists(testFactory.DecryptedContentFilePath));
+            Assert.Equal(testFactory.Content, decryptedContent.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+        }
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public void DecryptFileAndVerify_DecryptSignedAndEncryptedFileDifferentKeys(KeyType keyType)
         {
             // Arrange

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
@@ -2624,7 +2624,7 @@ namespace PgpCore
 
                     message = plainFact.NextPgpObject();
                 }
-                else
+                else if (!(message is PgpCompressedData))
                     throw new PgpException("File was not signed.");
             }
 
@@ -2749,7 +2749,7 @@ namespace PgpCore
 
                     message = plainFact.NextPgpObject();
                 }
-                else
+                else if (!(message is PgpCompressedData))
                     throw new PgpException("File was not signed.");
             }
 


### PR DESCRIPTION
When running DecryptAndVerify on an encrypted file that is also compressed the verification part fails with a PgpException and a message stating 'File was not signed.'

By simply letting the process continue and be picked up by the remainder of the current method the signature can be verified correctly. See the added tests to verify functionality.