### PR TITLE
Add ASCII armor support

### DIFF
--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -1767,6 +1767,22 @@ namespace PgpCore
         }
 
         #endregion DecryptStreamAndVerify
+        #region DecryptArmorAndVerify
+        public string DecryptArmorAndVerify(string inputData, string publicKey, string privateKey, string passphrase)
+        {
+	        var inputStream  = inputData.GetStream();
+	        var privateKeyIn = privateKey.GetStream(Encoding.ASCII);
+	        var publicKeyIn = publicKey.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        DecryptStreamAndVerify(inputStream, outStream, publicKeyIn, privateKeyIn, passphrase);
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion DecryptArmorAndVerify
         #region VerifyFileAsync
 
         /// <summary>
@@ -2014,6 +2030,15 @@ namespace PgpCore
         }
 
         #endregion VerifyStream
+        #region VerifyArmor
+        public bool VerifyArmor(string inputData, string key)
+        {
+	        var inputStream  = inputData.GetStream();
+	        var keyIn  = key.GetStream(Encoding.ASCII);
+
+	        return VerifyStream(inputStream, keyIn);
+        }
+        #endregion VerifyArmor
         #region VerifyClearStreamAsync
 
         /// <summary>
@@ -2092,6 +2117,14 @@ namespace PgpCore
         }
 
         #endregion VerifyClearStream
+        #region VerifyClearArmor
+        public bool VerifyClearArmor(string inputData)
+        {
+	        var inputStream = inputData.GetStream();
+
+	        return VerifyClear(inputStream);
+        }
+        #endregion VerifyClearArmor
         #endregion DecryptAndVerify
 
         #region GenerateKey

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -822,6 +822,22 @@ namespace PgpCore
         }
 
         #endregion EncryptStreamAndSign
+        #region EncryptArmorAndSign
+        public string EncryptArmorAndSign(string inputData, string publicKey, string privateKey, string passphrase)
+        {
+	        var inputStream = inputData.GetStream();
+	        var publicKeyIn = publicKey.GetStream(Encoding.ASCII);
+	        var privateKeyIn = privateKey.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        EncryptStreamAndSign(inputStream, outStream, new EncryptionKeys(publicKeyIn, privateKeyIn, passphrase));
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion EncryptArmorAndSign
         #endregion Encrypt and Sign
 
         #region Sign
@@ -1106,6 +1122,21 @@ namespace PgpCore
         }
 
         #endregion SignStream
+        #region SignArmor
+        public string SignArmor(string inputData, string key)
+        {
+	        var inputStream = inputData.GetStream();
+	        var keyIn       = key.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        SignStream(inputStream, outStream, new EncryptionKeys(keyIn));
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion SignArmor
         #endregion Sign
 
         #region ClearSign
@@ -1304,6 +1335,21 @@ namespace PgpCore
         }
 
         #endregion ClearSignStream
+        #region ClearSignArmor
+        public string ClearSignArmor(string inputData, string key, string passphrase)
+        {
+	        var inputStream = inputData.GetStream();
+	        var keyIn       = key.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        ClearSignStream(inputStream, outStream, keyIn, passphrase);
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion ClearSignArmor
         #endregion ClearSign
 
         #region Decrypt

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -831,7 +831,7 @@ namespace PgpCore
 
 	        var outStream = new MemoryStream();
 
-	        EncryptStreamAndSign(inputStream, outStream, new EncryptionKeys(publicKeyIn, privateKeyIn, passphrase));
+	        EncryptStreamAndSign(inputStream, outStream, publicKeyIn, privateKeyIn, passphrase);
 
 	        outStream.Seek(0, SeekOrigin.Begin);
 
@@ -1123,14 +1123,14 @@ namespace PgpCore
 
         #endregion SignStream
         #region SignArmor
-        public string SignArmor(string inputData, string key)
+        public string SignArmor(string inputData, string key, string passphrase)
         {
 	        var inputStream = inputData.GetStream();
 	        var keyIn       = key.GetStream(Encoding.ASCII);
 
 	        var outStream = new MemoryStream();
 
-	        SignStream(inputStream, outStream, new EncryptionKeys(keyIn));
+	        SignStream(inputStream, outStream, keyIn, passphrase);
 
 	        outStream.Seek(0, SeekOrigin.Begin);
 

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -458,6 +458,21 @@ namespace PgpCore
         }
 
         #endregion EncryptStream
+        #region EncryptArmor
+        public string EncryptArmor(string inputData, string key)
+        {
+	        var inputStream = inputData.GetStream();
+	        var keyIn       = key.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        EncryptStream(inputStream, outStream, keyIn);
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion EncryptArmor
         #endregion Encrypt
 
         #region Encrypt and Sign

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -849,7 +849,7 @@ namespace PgpCore
         /// <param name="outputFilePath">Output PGP signed file path</param>
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(string inputFilePath, string outputFilePath, 
+        public async Task SignFileAsync(string inputFilePath, string outputFilePath,
             bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
         {
             if (String.IsNullOrEmpty(inputFilePath))
@@ -908,7 +908,7 @@ namespace PgpCore
         /// <param name="encryptionKeys">Encryption keys</param>
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, 
+        public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
             bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
         {
             EncryptionKeys = encryptionKeys;
@@ -1488,6 +1488,21 @@ namespace PgpCore
         }
 
         #endregion DecryptStream
+        #region DecryptArmor
+        public string DecryptArmor(string inputData, string key, string passphrase)
+        {
+	        var inputStream = inputData.GetStream();
+	        var keyIn       = key.GetStream(Encoding.ASCII);
+
+	        var outStream = new MemoryStream();
+
+	        DecryptStream(inputStream, outStream, keyIn, passphrase);
+
+	        outStream.Seek(0, SeekOrigin.Begin);
+
+	        return outStream.GetString();
+        }
+        #endregion DecryptArmor
         #endregion Decrypt
 
         #region DecryptAndVerify
@@ -2505,7 +2520,7 @@ namespace PgpCore
                     message = plainFact.NextPgpObject();
                 }
             }
-            
+
             if (message is PgpCompressedData)
             {
                 PgpCompressedData cData = (PgpCompressedData)message;
@@ -3327,7 +3342,7 @@ namespace PgpCore
 
             publicOut.Dispose();
         }
-        
+
         /*
         * Search a secret key ring collection for a secret key corresponding to keyId if it exists.
         */

--- a/PgpCore/StreamHelper.cs
+++ b/PgpCore/StreamHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Text;
+
+namespace PgpCore
+{
+	public static class StreamHelper
+	{
+		public static Stream GetStream(this string s, Encoding encoding = null)
+		{
+			var stream = new MemoryStream();
+			var writer = encoding != null ? new StreamWriter(stream, encoding) : new StreamWriter(stream);
+			writer.Write(s);
+			writer.Flush();
+			stream.Position = 0;
+			return stream;
+		}
+
+		public static string GetString(this Stream inputStream)
+		{
+			var reader = new StreamReader(inputStream);
+			var       output = reader.ReadToEnd();
+			return output;
+		}
+	}
+}


### PR DESCRIPTION
Allow the user to pass keys and messages into methods as ASCII armor format, and to get armor format back using simple strings.

This means the user does not have to worry about creating `Stream`s etc. if they just have a key and message in memory to work with.

(also a Visual Studio plugin removed some trailing whitespace apparently too)