### PR TITLE
DecryptAndVerify verify that a signature exist for compressed files

### DIFF
--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -4709,10 +4709,7 @@ namespace PgpCore
                 }
                 else
                 {
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    Streams.PipeAll(unc, outputStream);
+                    throw new PgpException("File was not signed.");
                 }
             }
             else if (message is PgpLiteralData)


### PR DESCRIPTION
When provided with an encrypted and compressed file, DecryptAndVerify happily decrypts the file even though its not signed.

Added a failing unit test and updated it to throw a PgpException like its uncompressed counterpart