### PR TITLE
Add ability to extract clear-signed content when verifying signature

### DIFF
--- a/PgpCore.Tests/UnitTests/LegacyUnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/LegacyUnitTestsAsync.cs
@@ -1232,11 +1232,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = await pgp.ClearSignArmoredStringAsync(testFactory.Content, privateKey, testFactory.Password);
-            (bool verified, string message) = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
+            VerificationResult result = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
 
             // Assert
-            Assert.True(verified);
-            Assert.Equal(testFactory.Content, message?.Trim());
+            Assert.True(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();
@@ -1260,11 +1260,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = await pgp.ClearSignArmoredStringAsync(testFactory.Content, privateKey, testFactory.Password);
-            (bool verified, string message) = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
+            VerificationResult result = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
 
             // Assert
-            Assert.False(verified);
-            Assert.Equal(testFactory.Content, message?.Trim());
+            Assert.False(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();

--- a/PgpCore.Tests/UnitTests/LegacyUnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/LegacyUnitTestsAsync.cs
@@ -1221,6 +1221,60 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public async Task ClearSignAndVerifyArmoredStringAsync_CreateClearSignedStringAndVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            await testFactory.ArrangeAsync(keyType, FileType.Known);
+            string publicKey = testFactory.PublicKey;
+            string privateKey = testFactory.PrivateKey;
+            PGP pgp = new PGP();
+
+            // Act
+            string clearSignedContent = await pgp.ClearSignArmoredStringAsync(testFactory.Content, privateKey, testFactory.Password);
+            (bool verified, string message) = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
+
+            // Assert
+            Assert.True(verified);
+            Assert.Equal(testFactory.Content, message?.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public async Task ClearSignAndDoNotVerifyArmoredStringAsync_CreateClearSignedStringAndDoNotVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            TestFactory testFactory2 = new TestFactory();
+            await testFactory.ArrangeAsync(keyType, FileType.Known);
+            string privateKey = testFactory.PrivateKey;
+            await testFactory2.ArrangeAsync(KeyType.Generated);
+            string publicKey = testFactory2.PublicKey;
+
+            PGP pgp = new PGP();
+
+            // Act
+            string clearSignedContent = await pgp.ClearSignArmoredStringAsync(testFactory.Content, privateKey, testFactory.Password);
+            (bool verified, string message) = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent, publicKey);
+
+            // Assert
+            Assert.False(verified);
+            Assert.Equal(testFactory.Content, message?.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+            testFactory2.Teardown();
+        }
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public async Task EncryptArmoredStringAsync_CreateEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/LegacyUnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/LegacyUnitTestsSync.cs
@@ -1319,11 +1319,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content, privateKey, testFactory.Password);
-            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message, publicKey);
+            VerificationResult result = pgp.VerifyAndReadClearArmoredString(clearSignedContent, publicKey);
 
             // Assert
-            Assert.True(verified);
-            Assert.Equal(testFactory.Content, message.TrimEnd());
+            Assert.True(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
             
             // Teardown
             testFactory.Teardown();
@@ -1347,11 +1347,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content, privateKey, testFactory.Password);
-            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message, publicKey);
+            VerificationResult result = pgp.VerifyAndReadClearArmoredString(clearSignedContent, publicKey);
 
             // Assert
-            Assert.False(verified);
-            Assert.Equal(testFactory.Content, message.TrimEnd());
+            Assert.False(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();

--- a/PgpCore.Tests/UnitTests/LegacyUnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/LegacyUnitTestsSync.cs
@@ -1308,6 +1308,60 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public void ClearSignAndVerifyArmoredString_CreateClearSignedStringAndVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            testFactory.Arrange(keyType, FileType.Known);
+            string publicKey = System.IO.File.ReadAllText(testFactory.PublicKeyFilePath);
+            string privateKey = System.IO.File.ReadAllText(testFactory.PrivateKeyFilePath);
+            PGP pgp = new PGP();
+
+            // Act
+            string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content, privateKey, testFactory.Password);
+            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message, publicKey);
+
+            // Assert
+            Assert.True(verified);
+            Assert.Equal(testFactory.Content, message.TrimEnd());
+            
+            // Teardown
+            testFactory.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public void ClearSignAndDoNotVerifyArmoredString_CreateClearSignedStringAndDoNotVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            TestFactory testFactory2 = new TestFactory();
+            testFactory.Arrange(keyType, FileType.Known);
+            string privateKey = System.IO.File.ReadAllText(testFactory.PrivateKeyFilePath);
+            testFactory2.Arrange(KeyType.Generated);
+            string publicKey = System.IO.File.ReadAllText(testFactory2.PublicKeyFilePath);
+
+            PGP pgp = new PGP();
+
+            // Act
+            string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content, privateKey, testFactory.Password);
+            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message, publicKey);
+
+            // Assert
+            Assert.False(verified);
+            Assert.Equal(testFactory.Content, message.TrimEnd());
+
+            // Teardown
+            testFactory.Teardown();
+            testFactory2.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public void EncryptArmor_CreateEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
@@ -2278,11 +2278,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = await pgp.ClearSignArmoredStringAsync(testFactory.Content);
-            (bool verified, string message) = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent);
+            VerificationResult result = await pgp.VerifyAndReadClearArmoredStringAsync(clearSignedContent);
 
             // Assert
-            Assert.True(verified);
-            Assert.Equal(testFactory.Content, message.Trim());
+            Assert.True(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();
@@ -2308,11 +2308,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = await pgpEncrypt.ClearSignArmoredStringAsync(testFactory.Content);
-            (bool verified, string message) = await pgpDecrypt.VerifyAndReadClearArmoredStringAsync(clearSignedContent);
+            VerificationResult result = await pgpDecrypt.VerifyAndReadClearArmoredStringAsync(clearSignedContent);
 
             // Assert
-            Assert.False(verified);
-            Assert.Equal(testFactory.Content, message.Trim());
+            Assert.False(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd()); 
 
             // Teardown
             testFactory.Teardown();

--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -2139,6 +2139,61 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        public void ClearSignAndVerifyArmoredString_CreateClearSignedStringAndVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            testFactory.Arrange(keyType, FileType.Known);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            PGP pgp = new PGP(encryptionKeys);
+
+            // Act
+            string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content);
+            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message);
+
+            // Assert
+            Assert.True(verified);
+            Assert.Equal(testFactory.Content, message.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        public void ClearSignAndDoNotVerifyArmoredString_CreateClearSignedStringAndDoNotVerifyAndRead(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            TestFactory testFactory2 = new TestFactory();
+            testFactory.Arrange(keyType, FileType.Known);
+            testFactory2.Arrange(KeyType.Generated);
+
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
+
+            PGP pgpEncrypt = new PGP(encryptionKeys);
+            PGP pgpDecrypt = new PGP(decryptionKeys);
+
+            // Act
+            string clearSignedContent = pgpEncrypt.ClearSignArmoredString(testFactory.Content);
+            bool verified = pgpDecrypt.VerifyAndReadClearArmoredString(clearSignedContent, out string message);
+
+            // Assert
+            Assert.False(verified);
+            Assert.Equal(testFactory.Content, message.Trim());
+
+            // Teardown
+            testFactory.Teardown();
+            testFactory2.Teardown();
+        }
+
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
         public void EncryptArmoredString_CreateEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -2183,11 +2183,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = pgp.ClearSignArmoredString(testFactory.Content);
-            bool verified = pgp.VerifyAndReadClearArmoredString(clearSignedContent, out string message);
+            VerificationResult result = pgp.VerifyAndReadClearArmoredString(clearSignedContent);
 
             // Assert
-            Assert.True(verified);
-            Assert.Equal(testFactory.Content, message.Trim());
+            Assert.True(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();
@@ -2213,11 +2213,11 @@ namespace PgpCore.Tests
 
             // Act
             string clearSignedContent = pgpEncrypt.ClearSignArmoredString(testFactory.Content);
-            bool verified = pgpDecrypt.VerifyAndReadClearArmoredString(clearSignedContent, out string message);
+            VerificationResult result = pgpDecrypt.VerifyAndReadClearArmoredString(clearSignedContent);
 
             // Assert
-            Assert.False(verified);
-            Assert.Equal(testFactory.Content, message.Trim());
+            Assert.False(result.IsVerified);
+            Assert.Equal(testFactory.Content, result.ClearText.TrimEnd());
 
             // Teardown
             testFactory.Teardown();

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -27,10 +27,10 @@ namespace PgpCore
 		public string ClearText { get; private set; }
 
 		public VerificationResult(bool isVerified, string clearText)
-        {
+		{
 			IsVerified = isVerified;
 			ClearText = clearText;
-        }
+		}
 	}
 
 	public class PGP : IPGPEncrypt, IPGPEncryptAsync, IPGPSign, IPGPSignAsync

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -21,6 +21,18 @@ namespace PgpCore
 		UTF8
 	}
 
+	public struct VerificationResult
+	{
+		public bool IsVerified { get; private set; }
+		public string ClearText { get; private set; }
+
+		public VerificationResult(bool isVerified, string clearText)
+        {
+			IsVerified = isVerified;
+			ClearText = clearText;
+        }
+	}
+
 	public class PGP : IPGPEncrypt, IPGPEncryptAsync, IPGPSign, IPGPSignAsync
 	{
 		public static PGP Instance => _instance ?? (_instance = new PGP());
@@ -4088,13 +4100,14 @@ namespace PgpCore
 		}
 
 		#endregion VerifyClearArmoredString
+
         #region VerifyAndReadClearArmoredStringAsync
         /// <summary>
         /// PGP verify a given clear signed string.
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
         /// <param name="publicKey">PGP public key</param>
-        public async Task<(bool, string)> VerifyAndReadClearArmoredStringAsync(string input, string publicKey)
+        public async Task<VerificationResult> VerifyAndReadClearArmoredStringAsync(string input, string publicKey)
         {
             if (publicKey == null)
                 throw new ArgumentNullException("publicKey");
@@ -4109,7 +4122,7 @@ namespace PgpCore
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
         /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<(bool, string)> VerifyAndReadClearArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
+        public async Task<VerificationResult> VerifyAndReadClearArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
         {
             EncryptionKeys = encryptionKeys;
 
@@ -4120,7 +4133,7 @@ namespace PgpCore
         /// PGP verify a given clear signed string.
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
-        public async Task<(bool, string)> VerifyAndReadClearArmoredStringAsync(string input)
+        public async Task<VerificationResult> VerifyAndReadClearArmoredStringAsync(string input)
         {
             if (input == null)
                 throw new ArgumentNullException("input");
@@ -4134,47 +4147,45 @@ namespace PgpCore
                 using (StreamReader reader = new StreamReader(outputStream))
                 {
                     string message = reader.ReadToEnd();
-                    return (verified, message);
+                    return new VerificationResult(verified, message);
                 }
             }
         }
         #endregion VerifyAndReadClearArmoredStringAsync
+
         #region VerifyAndReadClearArmoredString
         /// <summary>
         /// PGP verify a given clear signed string.
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="message">On return, contains the clear text.</param>
         /// <param name="publicKey">PGP public key</param>
-        public bool VerifyAndReadClearArmoredString(string input, out string message, string publicKey)
+        public VerificationResult VerifyAndReadClearArmoredString(string input, string publicKey)
         {
             if (publicKey == null)
                 throw new ArgumentNullException("publicKey");
 
             EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
 
-            return VerifyAndReadClearArmoredString(input, out message);
+            return VerifyAndReadClearArmoredString(input);
         }
 
         /// <summary>
         /// PGP verify a given clear signed string.
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="message">On return, contains the clear text.</param>
         /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyAndReadClearArmoredString(string input, out string message, IEncryptionKeys encryptionKeys)
+        public VerificationResult VerifyAndReadClearArmoredString(string input, IEncryptionKeys encryptionKeys)
         {
             EncryptionKeys = encryptionKeys;
 
-            return VerifyAndReadClearArmoredString(input, out message);
+            return VerifyAndReadClearArmoredString(input);
         }
 
         /// <summary>
         /// PGP verify a given clear signed string.
         /// </summary>
         /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="message">On return, contains the clear text.</param>
-        public bool VerifyAndReadClearArmoredString(string input, out string message)
+        public VerificationResult VerifyAndReadClearArmoredString(string input)
         {
             if (input == null)
                 throw new ArgumentNullException("input");
@@ -4187,12 +4198,13 @@ namespace PgpCore
                 outputStream.Position = 0;
                 using (StreamReader reader = new StreamReader(outputStream))
                 {
-                    message = reader.ReadToEnd();
-                    return verified;
+                    string message = reader.ReadToEnd();
+					return new VerificationResult(verified, message);
                 }
             }
         }
         #endregion VerifyAndReadClearArmoredString
+
 		#endregion DecryptAndVerify
 
 		#region GetRecipients

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -10,10 +10,10 @@
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
     <PackageTags>PGP .NET Core</PackageTags>
-    <Version>5.5.0</Version>
+    <Version>5.5.1</Version>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.5.0.0</FileVersion>
-    <PackageReleaseNotes>v5.5.0 - Fix verification</PackageReleaseNotes>
+    <FileVersion>5.5.1.0</FileVersion>
+    <PackageReleaseNotes>v5.5.1 - Add stream checks</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
I've added additional versions of VerifyClearArmoredString+Async to output the content as part of performing verification.

I've also remove an unused variable (outputStream) in the VerifyArmoredString methods (which admittedly could have been a separate commit).

This (at least partially) addresses #77. 
