### PR TITLE
Allow for subkeys to be used for encryption

### DIFF
--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -438,7 +438,7 @@ namespace PgpCore
 
                     const int encryptKeyFlags = PgpKeyFlags.CanEncryptCommunications | PgpKeyFlags.CanEncryptStorage;
 
-                    foreach (PgpPublicKey key in keys.Where(k => k.Version >= 4 && k.IsMasterKey))
+                    foreach (PgpPublicKey key in keys.Where(k => k.Version >= 4))
                     {
                         foreach (PgpSignature s in key.GetSignatures())
                         {


### PR DESCRIPTION
When I used a key ring containing a masterkey for signing and a subkey for encryption, the library always used the masterkey, even though it did not contain keyflags for encryption.

After some digging, I found this check in the ReadPublicKey method, where only masterkeys are checked. After cloning and removing the masterkey check, the library encrypts with the subkey as expected.