### PR TITLE
Rewrite for subkey support

### DIFF
--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -3,573 +3,411 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PgpCore
 {
-    public class EncryptionKeys : IEncryptionKeys
-    {
-        #region Instance Members (Public)
-        public PgpPublicKey PublicKey => PublicKeys.FirstOrDefault();
-        public IEnumerable<PgpPublicKey> PublicKeys => _publicKeys.Value;
-        public PgpPrivateKey PrivateKey => _privateKey.Value;
-        public PgpSecretKey SecretKey => _secretKey.Value;
-        public PgpSecretKeyRingBundle SecretKeys => _secretKeys.Value;
+	public class EncryptionKeys : IEncryptionKeys
+	{
+		#region Instance Members (Public)
 
-        #endregion Instance Members (Public)
+		public IEnumerable<PgpPublicKey> EncryptKeys => _encryptKeys.Value;
+		public IEnumerable<PgpPublicKey> VerificationKeys => _verificationKeys.Value;
+		public PgpPrivateKey SigningPrivateKey => _signingPrivateKey.Value;
+		public PgpSecretKey SigningSecretKey => _signingSecretKey.Value;
+		public IEnumerable<PgpPublicKey> PublicKeys => EncryptKeys;
+		public PgpPublicKey PublicKey => EncryptKeys.FirstOrDefault();
+		public PgpPrivateKey PrivateKey => SigningPrivateKey;
+		public PgpSecretKey SecretKey => SigningSecretKey;
+		public PgpSecretKeyRingBundle SecretKeys => _secretKeys.Value;
 
-        #region Instance Members (Private)
-        private readonly string _passPhrase;
-        private Lazy<IEnumerable<PgpPublicKey>> _publicKeys;
-        private Lazy<PgpPrivateKey> _privateKey;
-        private Lazy<PgpSecretKey> _secretKey;
-        private Lazy<PgpSecretKeyRingBundle> _secretKeys;
+		#endregion Instance Members (Public)
 
-        #endregion Instance Members (Private)
+		#region Instance Members (Private)
 
-        #region Constructors
+		private readonly string _passPhrase;
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKey">The key used to encrypt the data</param>
-        /// <param name="privateKey">The key used to sign the data.</param>
-        /// <param name="passPhrase">The password required to access the private key</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(string publicKey, string privateKey, string passPhrase)
-        {
-            if (String.IsNullOrEmpty(publicKey))
-                throw new ArgumentException("PublicKeyFilePath");
-            if (String.IsNullOrEmpty(privateKey))
-                throw new ArgumentException("PrivateKeyFilePath");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+		private Lazy<IEnumerable<PgpPublicKey>> _encryptKeys;
+		private Lazy<IEnumerable<PgpPublicKey>> _verificationKeys;
+		private Lazy<PgpPrivateKey> _signingPrivateKey;
+		private Lazy<PgpSecretKey> _signingSecretKey;
+		private Lazy<PgpSecretKeyRingBundle> _secretKeys;
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKey.GetStream()) };
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKey.GetStream());
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKey.GetStream()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+		#endregion Instance Members (Private)
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeyFile">The key used to encrypt the data</param>
-        /// <param name="privateKeyFile">The key used to sign the data.</param>
-        /// <param name="passPhrase">The password required to access the private key</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(FileInfo publicKeyFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            if (publicKeyFile == null)
-                throw new ArgumentException("PublicKeyFile");
-            if (privateKeyFile == null)
-                throw new ArgumentException("PrivateKeyFile");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+		#region Constructors
 
-            if (!publicKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("Public Key file [{0}] does not exist.", publicKeyFile.FullName));
-            if (!privateKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("Private Key file [{0}] does not exist.", privateKeyFile.FullName));
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKey">The key used to encrypt the data</param>
+		/// <param name="privateKey">The key used to sign the data.</param>
+		/// <param name="passPhrase">The password required to access the private key</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(string publicKey, string privateKey, string passPhrase)
+		{
+			if (string.IsNullOrEmpty(publicKey))
+				throw new ArgumentException("PublicKeyFilePath");
+			if (string.IsNullOrEmpty(privateKey))
+				throw new ArgumentException("PrivateKeyFilePath");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKeyFile) };
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyFile);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyFile.OpenRead()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			var keyRings = Utilities.ReadAllKeyRings(publicKey.GetStream());
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two or more keys are required to encrypt and sign data. Your private key and the recipients public key(s).
-        /// The data is encrypted with the recipients public key(s) and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeys">The key(s) used to encrypt the data</param>
-        /// <param name="privateKey">The key used to sign the data.</param>
-        /// <param name="passPhrase">The password required to access the private key</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(IEnumerable<string> publicKeys, string privateKey, string passPhrase)
-        {
-            if (String.IsNullOrEmpty(privateKey))
-                throw new ArgumentException("PrivateKeyFilePath");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKey.GetStream()));
 
-            foreach (string publicKey in publicKeys)
-            {
-                if (String.IsNullOrEmpty(publicKey))
-                    throw new ArgumentException(nameof(publicKey));
-            }
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeys.Select(x => Utilities.ReadPublicKey(x.GetStream())).ToList();
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKey.GetStream());
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKey.GetStream()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeyFile">The key used to encrypt the data</param>
+		/// <param name="privateKeyFile">The key used to sign the data.</param>
+		/// <param name="passPhrase">The password required to access the private key</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(FileInfo publicKeyFile, FileInfo privateKeyFile, string passPhrase)
+		{
+			if (publicKeyFile == null)
+				throw new ArgumentException("PublicKeyFile");
+			if (privateKeyFile == null)
+				throw new ArgumentException("PrivateKeyFile");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two or more keys are required to encrypt and sign data. Your private key and the recipients public key(s).
-        /// The data is encrypted with the recipients public key(s) and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeyFilePaths">The key(s) used to encrypt the data</param>
-        /// <param name="privateKeyFilePath">The key used to sign the data.</param>
-        /// <param name="passPhrase">The password required to access the private key</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(IEnumerable<FileInfo> publicKeyFiles, FileInfo privateKeyFile, string passPhrase)
-        {
-            // Avoid multiple enumerations of 'publicKeyFilePaths'
-            FileInfo[] publicKeys = publicKeyFiles.ToArray();
+			if (!publicKeyFile.Exists)
+				throw new FileNotFoundException($"Public Key file [{publicKeyFile.FullName}] does not exist.");
+			if (!privateKeyFile.Exists)
+				throw new FileNotFoundException($"Private Key file [{privateKeyFile.FullName}] does not exist.");
 
-            if (privateKeyFile == null)
-                throw new ArgumentException("PrivateKeyFile");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyFile.OpenRead());
 
-            if (!privateKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("Private Key file [{0}] does not exist.", privateKeyFile.FullName));
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyFile.OpenRead()));
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-            foreach (FileInfo publicKeyFile in publicKeys)
-            {
-                if (publicKeyFile == null)
-                    throw new ArgumentException(nameof(publicKeyFile.FullName));
-                if (!File.Exists(publicKeyFile.FullName))
-                    throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", publicKeyFile.FullName));
-            }
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two or more keys are required to encrypt and sign data. Your private key and the recipients public key(s).
+		/// The data is encrypted with the recipients public key(s) and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeys">The key(s) used to encrypt the data</param>
+		/// <param name="privateKey">The key used to sign the data.</param>
+		/// <param name="passPhrase">The password required to access the private key</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(IEnumerable<string> publicKeys, string privateKey, string passPhrase)
+		{
+			if (string.IsNullOrEmpty(privateKey))
+				throw new ArgumentException("PrivateKeyFilePath");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeyFiles.Select(x => Utilities.ReadPublicKey(x)).ToList();
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyFile);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyFile.OpenRead()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			string[] publicKeyStrings = publicKeys.ToArray(); // Avoid multiple enumeration
+			foreach (string publicKey in publicKeyStrings)
+			{
+				if (string.IsNullOrEmpty(publicKey))
+					throw new ArgumentException(nameof(publicKey));
+			}
 
-        public EncryptionKeys(string privateKey, string passPhrase)
-        {
-            if (String.IsNullOrEmpty(privateKey))
-                throw new ArgumentException("PrivateKey");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyStrings.Select(s => s.GetStream()));
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return null;
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKey.GetStream());
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKey.GetStream()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKey.GetStream()));
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-        public EncryptionKeys(FileInfo privateKeyFile, string passPhrase)
-        {
-            if (privateKeyFile is null)
-                throw new ArgumentException("PrivateKeyFile");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two or more keys are required to encrypt and sign data. Your private key and the recipients public key(s).
+		/// The data is encrypted with the recipients public key(s) and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeyFiles">The key(s) used to encrypt the data</param>
+		/// <param name="privateKeyFile">The key used to sign the data.</param>
+		/// <param name="passPhrase">The password required to access the private key</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(IEnumerable<FileInfo> publicKeyFiles, FileInfo privateKeyFile, string passPhrase)
+		{
+			// Avoid multiple enumerations of 'publicKeyFilePaths'
+			FileInfo[] publicKeys = publicKeyFiles.ToArray();
 
-            if (!privateKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("Private Key file [{0}] does not exist.", privateKeyFile.FullName));
+			if (privateKeyFile == null)
+				throw new ArgumentException("PrivateKeyFile");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return null;
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyFile);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyFile.OpenRead()))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			if (!privateKeyFile.Exists)
+				throw new FileNotFoundException($"Private Key file [{privateKeyFile.FullName}] does not exist.");
 
-        public EncryptionKeys(Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
-        {
-            if (publicKeyStream == null)
-                throw new ArgumentException("PublicKeyStream");
-            if (privateKeyStream == null)
-                throw new ArgumentException("PrivateKeyStream");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+			FileInfo[] publicKeyFileInfos = publicKeys.ToArray(); // Avoid multiple enumeration
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKeyStream) };
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyStream);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyStream))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			foreach (FileInfo publicKeyFile in publicKeyFileInfos)
+			{
+				if (publicKeyFile == null)
+					throw new ArgumentException(nameof(publicKeyFile.FullName));
+				if (!File.Exists(publicKeyFile.FullName))
+					throw new FileNotFoundException($"Input file [{publicKeyFile.FullName}] does not exist.");
+			}
 
-        public EncryptionKeys(Stream privateKeyStream, string passPhrase)
-        {
-            if (privateKeyStream == null)
-                throw new ArgumentException("PrivateKeyStream");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
+			var keyRings = Utilities.ReadAllKeyRings(publicKeys.Select(fileInfo => fileInfo.OpenRead()));
 
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyStream);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyStream))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyFile.OpenRead()));
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-        public EncryptionKeys(IEnumerable<Stream> publicKeyStreams, Stream privateKeyStream, string passPhrase)
-        {
-            // Avoid multiple enumerations of 'publicKeyFilePaths'
-            Stream[] publicKeys = publicKeyStreams.ToArray();
+		public EncryptionKeys(string privateKey, string passPhrase)
+		{
+			if (string.IsNullOrEmpty(privateKey))
+				throw new ArgumentException("PrivateKey");
 
-            if (privateKeyStream == null)
-                throw new ArgumentException("PrivateKeyStream");
-            if (passPhrase == null)
-                throw new ArgumentNullException("Invalid Pass Phrase.");
-            foreach (Stream publicKey in publicKeys)
-            {
-                if (publicKey == null)
-                    throw new ArgumentException("PublicKeyStream");
-            }
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKey.GetStream()));
+			_passPhrase = passPhrase ?? throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
+			InitializeKeys();
+		}
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeyStreams.Select(x => Utilities.ReadPublicKey(x)).ToList();
-            });
-            _secretKey = new Lazy<PgpSecretKey>(() =>
-            {
-                return ReadSecretKey(privateKeyStream);
-            });
-            _secretKeys = new Lazy<PgpSecretKeyRingBundle>(() =>
-            {
-                using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyStream))
-                {
-                    return new PgpSecretKeyRingBundle(inputStream);
-                }
-            });
-            _privateKey = new Lazy<PgpPrivateKey>(() =>
-            {
-                return ReadPrivateKey(passPhrase);
-            });
-            _passPhrase = passPhrase;
-        }
+		public EncryptionKeys(FileInfo privateKeyFile, string passPhrase)
+		{
+			if (privateKeyFile is null)
+				throw new ArgumentException("PrivateKeyFile");
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKey">The key used to encrypt the data</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(string publicKey)
-        {
-            if (String.IsNullOrEmpty(publicKey))
-                throw new ArgumentException("PublicKey");
+			if (!privateKeyFile.Exists)
+				throw new FileNotFoundException($"Private Key file [{privateKeyFile.FullName}] does not exist.");
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKey.GetStream()) };
-            });
-        }
+			_secretKeys =
+				new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyFile.OpenRead()));
+			_passPhrase = passPhrase ?? throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
+			InitializeKeys();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeyFile">The key used to encrypt the data</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(FileInfo publicKeyFile)
-        {
-            if (publicKeyFile == null)
-                throw new ArgumentException("PublicKeyFilePath");
+		public EncryptionKeys(Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
+		{
+			if (publicKeyStream == null)
+				throw new ArgumentException("PublicKeyStream");
+			if (privateKeyStream == null)
+				throw new ArgumentException("PrivateKeyStream");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
 
-            if (!publicKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("Public Key file [{0}] does not exist.", publicKeyFile.FullName));
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyStream);
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKeyFile) };
-            });
-        }
+			_secretKeys = new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyStream));
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeys">The keys used to encrypt the data</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(IEnumerable<string> publicKeys)
-        {
-            foreach (string publicKey in publicKeys)
-            {
-                if (String.IsNullOrEmpty(publicKey))
-                    throw new ArgumentException(nameof(publicKey));
-            }
+		public EncryptionKeys(Stream privateKeyStream, string passPhrase)
+		{
+			if (privateKeyStream == null)
+				throw new ArgumentException("PrivateKeyStream");
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeys.Select(x => Utilities.ReadPublicKey(x.GetStream())).ToList();
-            });
-        }
+			_secretKeys = new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyStream));
+			_passPhrase = passPhrase ?? throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
+			InitializeKeys();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the EncryptionKeys class.
-        /// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
-        /// The data is encrypted with the recipients public key and signed with your private key.
-        /// </summary>
-        /// <param name="publicKeyFiles">The keys used to encrypt the data</param>
-        /// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
-        public EncryptionKeys(IEnumerable<FileInfo> publicKeyFiles)
-        {
-            // Avoid multiple enumerations of 'publicKeyFiles'
-            FileInfo[] publicKeys = publicKeyFiles.ToArray();
+		public EncryptionKeys(IEnumerable<Stream> publicKeyStreams, Stream privateKeyStream, string passPhrase)
+		{
+			// Avoid multiple enumerations of 'publicKeyFilePaths'
+			Stream[] publicKeyStreamArray = publicKeyStreams.ToArray();
 
-            foreach (FileInfo publicKeyFile in publicKeys)
-            {
-                if (publicKeyFile is null)
-                    throw new ArgumentException(nameof(publicKeyFile));
-                if (!publicKeyFile.Exists)
-                    throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", publicKeyFile.FullName));
-            }
+			if (privateKeyStream == null)
+				throw new ArgumentException("PrivateKeyStream");
+			if (passPhrase == null)
+				throw new ArgumentNullException(nameof(passPhrase), "Invalid Pass Phrase.");
+			foreach (Stream publicKeyStream in publicKeyStreamArray)
+			{
+				if (publicKeyStream == null)
+					throw new ArgumentException("PublicKeyStream");
+			}
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeyFiles.Select(x => Utilities.ReadPublicKey(x)).ToList();
-            });
-        }
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyStreamArray);
 
-        public EncryptionKeys(Stream publicKeyStream)
-        {
-            if (publicKeyStream == null)
-                throw new ArgumentException("PublicKeyStream");
+			_secretKeys = new Lazy<PgpSecretKeyRingBundle>(() => Utilities.ReadSecretKeyRingBundle(privateKeyStream));
+			_passPhrase = passPhrase;
+			InitializeKeys(keyRings);
+		}
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return new List<PgpPublicKey>() { Utilities.ReadPublicKey(publicKeyStream) };
-            });
-        }
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKey">The key used to encrypt the data</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(string publicKey)
+		{
+			if (string.IsNullOrEmpty(publicKey))
+				throw new ArgumentException("PublicKey");
 
-        public EncryptionKeys(IEnumerable<Stream> publicKeyStreams)
-        {
-            Stream[] publicKeys = publicKeyStreams.ToArray();
+			var keyRings = Utilities.ReadAllKeyRings(publicKey.GetStream());
 
-            foreach (Stream publicKey in publicKeys)
-            {
-                if (publicKey == null)
-                    throw new ArgumentException("PublicKeyStream");
-            }
+			InitializeKeys(keyRings);
+		}
 
-            _publicKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-            {
-                return publicKeyStreams.Select(x => Utilities.ReadPublicKey(x)).ToList();
-            });
-        }
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeyFile">The key used to encrypt the data</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(FileInfo publicKeyFile)
+		{
+			if (publicKeyFile == null)
+				throw new ArgumentException("PublicKeyFilePath");
 
-        #endregion Constructors
+			if (!publicKeyFile.Exists)
+				throw new FileNotFoundException($"Public Key file [{publicKeyFile.FullName}] does not exist.");
 
-        #region Public Methods
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyFile.OpenRead());
 
-        public PgpPrivateKey FindSecretKey(long keyId)
-        {
-            PgpSecretKey pgpSecKey = SecretKeys.GetSecretKey(keyId);
+			InitializeKeys(keyRings);
+		}
 
-            if (pgpSecKey == null)
-                return null;
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeys">The keys used to encrypt the data</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(IEnumerable<string> publicKeys)
+		{
+			string[] publicKeyStrings = publicKeys.ToArray();
+			foreach (string publicKey in publicKeyStrings)
+			{
+				if (string.IsNullOrEmpty(publicKey))
+					throw new ArgumentException(nameof(publicKey));
+			}
 
-            return pgpSecKey.ExtractPrivateKey(_passPhrase.ToCharArray());
-        }
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyStrings.Select(s => s.GetStream()));
 
-        #endregion Public Methods
+			InitializeKeys(keyRings);
+		}
 
-        #region Secret Key
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class.
+		/// Two keys are required to encrypt and sign data. Your private key and the recipients public key.
+		/// The data is encrypted with the recipients public key and signed with your private key.
+		/// </summary>
+		/// <param name="publicKeyFiles">The keys used to encrypt the data</param>
+		/// <exception cref="ArgumentException">Public key not found. Private key not found. Missing password</exception>
+		public EncryptionKeys(IEnumerable<FileInfo> publicKeyFiles)
+		{
+			// Avoid multiple enumerations of 'publicKeyFiles'
+			FileInfo[] publicKeys = publicKeyFiles.ToArray();
 
-        private PgpSecretKey ReadSecretKey(string privateKeyPath)
-        {
-            PgpSecretKey foundKey = GetFirstSecretKey(SecretKeys);
-            if (foundKey != null)
-                return foundKey;
-            throw new ArgumentException("Can't find signing key in key ring.");
-        }
+			foreach (FileInfo publicKeyFile in publicKeys)
+			{
+				if (publicKeyFile is null)
+					throw new ArgumentException(nameof(publicKeyFile));
+				if (!publicKeyFile.Exists)
+					throw new FileNotFoundException($"Input file [{publicKeyFile.FullName}] does not exist.");
+			}
 
-        private PgpSecretKey ReadSecretKey(FileInfo privateKeyFile)
-        {
-            PgpSecretKey foundKey = GetFirstSecretKey(SecretKeys);
-            if (foundKey != null)
-                return foundKey;
-            throw new ArgumentException("Can't find signing key in key ring.");
-        }
+			var keyRings = Utilities.ReadAllKeyRings(publicKeys.Select(fileInfo => fileInfo.OpenRead()));
 
-        private PgpSecretKey ReadSecretKey(Stream privateKeyStream)
-        {
-            PgpSecretKey foundKey = GetFirstSecretKey(SecretKeys);
-            if (foundKey != null)
-                return foundKey;
-            throw new ArgumentException("Can't find signing key in key ring.");
-        }
+			InitializeKeys(keyRings);
+		}
 
-        /// <summary>
-        /// Return the first key we can use to encrypt.
-        /// Note: A file can contain multiple keys (stored in "key rings")
-        /// </summary>
-        private PgpSecretKey GetFirstSecretKey(PgpSecretKeyRingBundle secretKeyRingBundle)
-        {
-            foreach (PgpSecretKeyRing kRing in secretKeyRingBundle.GetKeyRings())
-            {
-                PgpSecretKey key = kRing.GetSecretKeys()
-                    .Cast<PgpSecretKey>()
-                    .Where(k => k.IsSigningKey)
-                    .FirstOrDefault();
-                if (key != null)
-                    return key;
-            }
-            return null;
-        }
+		public EncryptionKeys(Stream publicKeyStream)
+		{
+			if (publicKeyStream == null)
+				throw new ArgumentException("PublicKeyStream");
 
-        #endregion Secret Key
+			var keyRings = Utilities.ReadAllKeyRings(publicKeyStream);
 
-        #region Public Key
-       
-        private PgpPublicKey GetFirstPublicKey(PgpPublicKeyRingBundle publicKeyRingBundle)
-        {
-            foreach (PgpPublicKeyRing kRing in publicKeyRingBundle.GetKeyRings())
-            {
-                PgpPublicKey key = kRing.GetPublicKeys()
-                    .Cast<PgpPublicKey>()
-                    .Where(k => k.IsEncryptionKey)
-                    .FirstOrDefault();
-                if (key != null)
-                    return key;
-            }
-            return null;
-        }
+			InitializeKeys(keyRings);
+		}
 
-        #endregion Public Key
+		public EncryptionKeys(IEnumerable<Stream> publicKeyStreams)
+		{
+			Stream[] publicKeys = publicKeyStreams.ToArray();
 
-        #region Private Key
+			foreach (Stream publicKey in publicKeys)
+			{
+				if (publicKey == null)
+					throw new ArgumentException("PublicKeyStream");
+			}
 
-        private PgpPrivateKey ReadPrivateKey(string passPhrase)
-        {
-            PgpPrivateKey privateKey = SecretKey.ExtractPrivateKey(passPhrase.ToCharArray());
-            if (privateKey != null)
-                return privateKey;
+			var keyRings = Utilities.ReadAllKeyRings(publicKeys);
+			
+			InitializeKeys(keyRings);
+		}
 
-            throw new ArgumentException("No private key found in secret key.");
-        }
+		#endregion Constructors
 
-        #endregion Private Key
-    }
+		#region Public Methods
+
+		public PgpPrivateKey FindSecretKey(long keyId)
+		{
+			PgpSecretKey pgpSecKey = SecretKeys.GetSecretKey(keyId);
+
+			if (pgpSecKey == null)
+				return null;
+
+			return pgpSecKey.ExtractPrivateKey(_passPhrase.ToCharArray());
+		}
+
+		#endregion Public Methods
+
+		#region Private Key
+
+		private PgpPrivateKey ReadPrivateKey(PgpSecretKey secretKey, string passPhrase)
+		{
+			PgpPrivateKey privateKey = secretKey.ExtractPrivateKey(passPhrase.ToCharArray());
+			if (privateKey != null)
+				return privateKey;
+
+			throw new ArgumentException("No private key found in secret key.");
+		}
+
+		#endregion Private Key
+
+		#region Helper Methods
+
+		private void
+			InitializeKeys(
+				IEnumerable<PgpPublicKeyRing> publicKeyRings =
+					null) // Should only be run as the last step during construction!
+		{
+			if (publicKeyRings == null)
+			{
+				_encryptKeys = new Lazy<IEnumerable<PgpPublicKey>>(() => null);
+				_verificationKeys = new Lazy<IEnumerable<PgpPublicKey>>(() => null);
+			}
+			else
+			{
+				// Need to consume the stream into a list before it is closed (can happen because of lazy instantiation).
+				_encryptKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
+					publicKeyRings.Select(Utilities.FindBestEncryptionKey).ToArray());
+				_verificationKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
+					publicKeyRings.Select(Utilities.FindBestVerificationKey).ToArray());
+			}
+
+			if (_secretKeys != null)
+			{
+				_signingSecretKey = new Lazy<PgpSecretKey>(() => Utilities.FindBestSigningKey(SecretKeys));
+				if (SigningSecretKey != null)
+					_signingPrivateKey = new Lazy<PgpPrivateKey>(() => ReadPrivateKey(SigningSecretKey, _passPhrase));
+			}
+			else
+			{
+				_secretKeys = new Lazy<PgpSecretKeyRingBundle>(() => null);
+			}
+		}
+
+		#endregion
+	}
 }

--- a/PgpCore/IEncryptionKeys.cs
+++ b/PgpCore/IEncryptionKeys.cs
@@ -11,6 +11,10 @@ namespace PgpCore
     /// </summary>
     public interface IEncryptionKeys
     {
+        IEnumerable<PgpPublicKey> EncryptKeys { get; }
+        IEnumerable<PgpPublicKey> VerificationKeys { get; }
+        PgpPrivateKey SigningPrivateKey { get; }
+        PgpSecretKey SigningSecretKey { get; }
         PgpPublicKey PublicKey { get; }
         IEnumerable<PgpPublicKey> PublicKeys { get; }
         PgpPrivateKey PrivateKey { get; }

--- a/PgpCore/IPGPEncrypt.cs
+++ b/PgpCore/IPGPEncrypt.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 
 namespace PgpCore
 {

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -1,5649 +1,5725 @@
-using Org.BouncyCastle.Asn1.Pkcs;
-using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
-using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
-using Org.BouncyCastle.X509;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace PgpCore
 {
-    public enum PGPFileType { Binary, Text, UTF8 }
-
-    public class PGP : IPGPEncrypt, IPGPEncryptAsync, IPGPSign, IPGPSignAsync, IDisposable
-    {
-        public static readonly PGP Instance = new PGP();
-
-        private const int BufferSize = 0x10000;
-        private const string DefaultFileName = "name";
-
-        public CompressionAlgorithmTag CompressionAlgorithm { get; set; } = CompressionAlgorithmTag.Uncompressed;
-
-        public SymmetricKeyAlgorithmTag SymmetricKeyAlgorithm { get; set; } = SymmetricKeyAlgorithmTag.TripleDes;
-
-        public int PgpSignatureType { get; set; } = PgpSignature.DefaultCertification;
-
-        public PublicKeyAlgorithmTag PublicKeyAlgorithm { get; set; } = PublicKeyAlgorithmTag.RsaGeneral;
-
-        public PGPFileType FileType { get; set; } = PGPFileType.Binary;
-
-        public HashAlgorithmTag HashAlgorithmTag { get; set; } = HashAlgorithmTag.Sha1;
-
-        public IEncryptionKeys EncryptionKeys { get; private set; }
-
-        #region Constructor
-
-        public PGP() { }
-
-        public PGP(IEncryptionKeys encryptionKeys) { EncryptionKeys = encryptionKeys; }
-
-        #endregion Constructor
-
-        #region Encrypt
-        #region EncryptFileAsync
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            string inputFilePath,
-            string outputFilePath,
-            string publicKeyFilePath,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="publicKeyFilePaths">PGP public key file paths</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            string inputFilePath,
-            string outputFilePath,
-            IEnumerable<string> publicKeyFilePaths,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList());
-            await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            string inputFilePath,
-            string outputFilePath,
-            IEncryptionKeys encryptionKeys,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            string inputFilePath,
-            string outputFilePath,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
-            using (Stream outputStream = File.Create(outputFilePath))
-                await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            FileInfo publicKeyFile,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="publicKeyFiles">PGP public key files</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            IEnumerable<FileInfo> publicKeyFiles,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFiles);
-            await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            IEncryptionKeys encryptionKeys,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAsync(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            using (FileStream inputStream = inputFile.OpenRead())
-            using (Stream outputStream = outputFile.OpenWrite())
-                await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        #endregion EncryptFileAsync
-        #region EncryptFile
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            string inputFilePath,
-            string outputFilePath,
-            string publicKeyFilePath,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            string inputFilePath,
-            string outputFilePath,
-            IEnumerable<string> publicKeyFilePaths,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList());
-            EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            string inputFilePath,
-            string outputFilePath,
-            IEncryptionKeys encryptionKeys,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted</param>
-        /// <param name="outputFilePath">Output PGP encrypted file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            string inputFilePath,
-            string outputFilePath,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
-            using (Stream outputStream = File.Create(outputFilePath))
-                EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            FileInfo publicKeyFile,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="publicKeyFiles">PGP public key files</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            IEnumerable<FileInfo> publicKeyFiles,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFiles);
-            EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            IEncryptionKeys encryptionKeys,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted</param>
-        /// <param name="outputFile">Output PGP encrypted file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFile(
-            FileInfo inputFile,
-            FileInfo outputFile,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            using (FileStream inputStream = inputFile.OpenRead())
-            using (Stream outputStream = outputFile.OpenWrite())
-                EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        #endregion EncryptFile
-        #region EncryptStreamAsync
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAsync(
-            Stream inputStream,
-            Stream outputStream,
-            Stream publicKeyStream,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStreams);
-            await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                outputStream = new ArmoredOutputStream(outputStream);
-            }
-
-            PgpEncryptedDataGenerator pk = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-
-            foreach (PgpPublicKey publicKey in EncryptionKeys.PublicKeys)
-            {
-                pk.AddMethod(publicKey);
-            }
-
-            Stream @out = pk.Open(outputStream, new byte[1 << 16]);
-
-            if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
-            {
-                PgpCompressedDataGenerator comData = new PgpCompressedDataGenerator(CompressionAlgorithm);
-                await Utilities.WriteStreamToLiteralDataAsync(comData.Open(@out), FileTypeToChar(), inputStream, name);
-                comData.Close();
-            }
-            else
-                await Utilities.WriteStreamToLiteralDataAsync(@out, FileTypeToChar(), inputStream, name);
-
-            @out.Close();
-
-            if (armor)
-            {
-                outputStream.Close();
-            }
-        }
-
-        #endregion EncryptStreamAsync
-        #region EncryptStream
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStream(
-            Stream inputStream,
-            Stream outputStream,
-            Stream publicKeyStream,
-            bool armor = true,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStream(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStreams);
-            EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// PGP Encrypt the stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted</param>
-        /// <param name="outputStream">Output PGP encrypted stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStream(Stream inputStream, Stream outputStream, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                outputStream = new ArmoredOutputStream(outputStream);
-            }
-
-            PgpEncryptedDataGenerator pk = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-
-            foreach (PgpPublicKey publicKey in EncryptionKeys.PublicKeys)
-            {
-                pk.AddMethod(publicKey);
-            }
-
-            Stream @out = pk.Open(outputStream, new byte[1 << 16]);
-
-            if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
-            {
-                PgpCompressedDataGenerator comData = new PgpCompressedDataGenerator(CompressionAlgorithm);
-                Utilities.WriteStreamToLiteralData(comData.Open(@out), FileTypeToChar(), inputStream, name);
-                comData.Close();
-            }
-            else
-                Utilities.WriteStreamToLiteralData(@out, FileTypeToChar(), inputStream, name);
-
-            @out.Close();
-
-            if (armor)
-            {
-                outputStream.Close();
-            }
-        }
-
-        #endregion EncryptStream
-        #region EncryptArmoredStringAsync
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAsync(
-            string input,
-            string publicKey,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="publicKeys">IEnumerable of PGP public keys</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAsync(string input, IEnumerable<string> publicKeys, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(await Task.WhenAll(publicKeys.Select(x => x.GetStreamAsync()).ToList()));
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAsync(string input, IEncryptionKeys encryptionKeys, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAsync(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion EncryptArmoredStringAsync
-        #region EncryptArmoredString
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredString(
-            string input,
-            string publicKey,
-            bool withIntegrityCheck = true,
-            string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="publicKeys">IEnumerable of PGP public keys</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredString(string input, IEnumerable<string> publicKeys, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeys.Select(x => x.GetStream()).ToList());
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredString(string input, IEncryptionKeys encryptionKeys, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP Encrypt the string.
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted</param>
-        /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredString(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion EncryptArmoredString
-        #endregion Encrypt
-
-        #region Encrypt and Sign
-        #region EncryptFileAndSignAsync
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, string publicKeyFilePath,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath), passPhrase);
-            await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, IEnumerable<string> publicKeyFilePaths,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList(), new FileInfo(privateKeyFilePath), passPhrase);
-            await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            if (name == DefaultFileName)
-            {
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        await OutputEncryptedAsync(inputFilePath, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    await OutputEncryptedAsync(inputFilePath, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
-            await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="publicKeyFiles">IEnumerable of PGP public key files</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, IEnumerable<FileInfo> publicKeyFiles,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFiles, privateKeyFile, passPhrase);
-            await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFilePath");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            if (name == DefaultFileName)
-            {
-                name = inputFile.Name;
-            }
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        await OutputEncryptedAsync(inputFile, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    await OutputEncryptedAsync(inputFile, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        #endregion EncryptFileAndSignAsync
-        #region EncryptFileAndSign
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(string inputFilePath, string outputFilePath, string publicKeyFilePath,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath), passPhrase);
-            EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(string inputFilePath, string outputFilePath, IEnumerable<string> publicKeyFilePaths,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList(), new FileInfo(privateKeyFilePath), passPhrase);
-            EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(string inputFilePath, string outputFilePath, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            if (name == DefaultFileName)
-            {
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        OutputEncrypted(inputFilePath, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    OutputEncrypted(inputFilePath, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
-            EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="publicKeyFiles">IEnumerable of PGP public key files</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, IEnumerable<FileInfo> publicKeyFiles,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFiles, privateKeyFile, passPhrase);
-            EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be encrypted and signed</param>
-        /// <param name="outputFile">Output PGP encrypted and signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
-        /// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFilePath");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            if (name == DefaultFileName)
-            {
-                name = inputFile.Name;
-            }
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        OutputEncrypted(inputFile, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    OutputEncrypted(inputFile, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        #endregion EncryptFileAndSign
-        #region EncryptStreamAndSignAsync
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, Stream publicKeyStream,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
-            await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStreams, privateKeyStream, passPhrase);
-            await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                {
-                    await OutputEncryptedAsync(inputStream, armoredOutputStream, withIntegrityCheck, name);
-                }
-            }
-            else
-                await OutputEncryptedAsync(inputStream, outputStream, withIntegrityCheck, name);
-        }
-
-        #endregion EncryptStreamAndSignAsync
-        #region EncryptStreamAndSign
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, Stream publicKeyStream,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
-            EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStreams, privateKeyStream, passPhrase);
-            EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Encrypt and sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be encrypted and signed</param>
-        /// <param name="outputStream">Output PGP encrypted and signed stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                {
-                    OutputEncrypted(inputStream, armoredOutputStream, withIntegrityCheck, name);
-                }
-            }
-            else
-                OutputEncrypted(inputStream, outputStream, withIntegrityCheck, name);
-        }
-
-        #endregion EncryptStreamAndSign
-        #region EncryptArmoredStringAndSignAsync
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAndSignAsync(string input, string publicKey,
-            string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync(), await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="publicKeys">IEnumerable of PGP public keys</param>
-        /// <param name="privateKey">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAndSignAsync(string input, List<string> publicKeys,
-            string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(await Task.WhenAll(publicKeys.Select(x => x.GetStreamAsync()).ToList()), await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAndSignAsync(string input, IEncryptionKeys encryptionKeys, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public async Task<string> EncryptArmoredStringAndSignAsync(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion EncryptArmoredStringAndSignAsync
-        #region EncryptArmoredStringAndSign
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredStringAndSign(string input, string publicKey,
-            string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKey.GetStream(), privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="publicKeys">IEnumerable of PGP public keys</param>
-        /// <param name="privateKey">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredStringAndSign(string input, List<string> publicKeys,
-            string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeys.Select(x => x.GetStream()).ToList(), privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Encrypt and sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
-        public string EncryptArmoredStringAndSign(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion EncryptArmoredStringAndSign
-        #endregion Encrypt and Sign
-
-        #region Sign
-        #region SignFileAsync
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(string inputFilePath, string outputFilePath,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            await SignFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await SignFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(string inputFilePath, string outputFilePath,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            if (name == DefaultFileName)
-            {
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        await OutputSignedAsync(inputFilePath, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    await OutputSignedAsync(inputFilePath, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            await SignFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await SignFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            if (name == DefaultFileName)
-            {
-                name = inputFile.Name;
-            }
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        await OutputSignedAsync(inputFile, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    await OutputSignedAsync(inputFile, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(FileInfo inputFile, FileInfo outputFile,
-            FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            SignFile(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            SignFile(inputFile, outputFile, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(FileInfo inputFile, FileInfo outputFile,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.FullName));
-
-            if (name == DefaultFileName)
-            {
-                name = inputFile.Name;
-            }
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        OutputSigned(inputFile, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    OutputSigned(inputFile, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        #endregion SignFileAsync
-        #region SignFile
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(string inputFilePath, string outputFilePath,
-            string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            SignFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            SignFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the file pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignFile(string inputFilePath, string outputFilePath,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            if (name == DefaultFileName)
-            {
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                if (armor)
-                {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                    {
-                        OutputSigned(inputFilePath, armoredOutputStream, withIntegrityCheck, name);
-                    }
-                }
-                else
-                    OutputSigned(inputFilePath, outputStream, withIntegrityCheck, name);
-            }
-        }
-
-        #endregion SignFile
-        #region SignStreamAsync
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignStreamAsync(Stream inputStream, Stream outputStream,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            await SignStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            await SignStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task SignStreamAsync(Stream inputStream, Stream outputStream,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                {
-                    await OutputSignedAsync(inputStream, armoredOutputStream, withIntegrityCheck, name);
-                }
-            }
-            else
-                await OutputSignedAsync(inputStream, outputStream, withIntegrityCheck, name);
-        }
-
-        #endregion SignStreamAsync
-        #region SignStream
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignStream(Stream inputStream, Stream outputStream,
-            Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            SignStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-            SignStream(inputStream, outputStream, armor, withIntegrityCheck, name);
-        }
-
-        /// <summary>
-        /// Sign the stream pointed to by unencryptedFileInfo and
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public void SignStream(Stream inputStream, Stream outputStream,
-            bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            if (name == DefaultFileName && inputStream is FileStream)
-            {
-                string inputFilePath = ((FileStream)inputStream).Name;
-                name = Path.GetFileName(inputFilePath);
-            }
-
-            if (armor)
-            {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-                {
-                    OutputSigned(inputStream, armoredOutputStream, withIntegrityCheck, name);
-                }
-            }
-            else
-                OutputSigned(inputStream, outputStream, withIntegrityCheck, name);
-        }
-
-        #endregion SignStream
-        #region SignArmoredStringAsync
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task<string> SignArmoredStringAsync(string input, string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await SignStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task<string> SignArmoredStringAsync(string input, IEncryptionKeys encryptionKeys,
-            bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await SignStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public async Task<string> SignArmoredStringAsync(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await SignStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion SignArmoredStringAsync
-        #region SignArmoredString
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public string SignArmoredString(string input, string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                SignStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public string SignArmoredString(string input, IEncryptionKeys encryptionKeys,
-            bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                SignStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Sign the string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="name">Name of signed file in message, defaults to the input file name</param>
-        public string SignArmoredString(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                SignStream(inputStream, outputStream, true, withIntegrityCheck, name);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion SignArmoredString
-        #endregion Sign
-
-        #region ClearSign
-        #region ClearSignFileAsync
-
-        // https://github.com/bcgit/bc-csharp/blob/f18a2dbbc2c1b4277e24a2e51f09cac02eedf1f5/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            await ClearSignFileAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await ClearSignFileAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                await OutputClearSignedAsync(inputFilePath, outputStream);
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            await ClearSignFileAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await ClearSignFileAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.Name));
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                await OutputClearSignedAsync(inputFile, outputStream);
-            }
-        }
-
-        #endregion ClearSignFileAsync
-        #region ClearSignFile
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void ClearSignFile(string inputFilePath, string outputFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            ClearSignFile(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void ClearSignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            ClearSignFile(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be signed</param>
-        /// <param name="outputFilePath">Output PGP signed file path</param>
-        public void ClearSignFile(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFilePath));
-
-            using (Stream outputStream = File.Create(outputFilePath))
-            {
-                OutputClearSigned(inputFilePath, outputStream);
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void ClearSignFile(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            ClearSignFile(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void ClearSignFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            ClearSignFile(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// Clear sign the file pointed to by unencryptedFileInfo
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be signed</param>
-        /// <param name="outputFile">Output PGP signed file</param>
-        public void ClearSignFile(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Input file [{0}] does not exist.", inputFile.Name));
-
-            using (Stream outputStream = outputFile.OpenWrite())
-            {
-                OutputClearSigned(inputFile, outputStream);
-            }
-        }
-
-        #endregion ClearSignFile
-        #region ClearSignStreamAsync
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            await ClearSignStreamAsync(inputStream, outputStream);
-        }
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await ClearSignStreamAsync(inputStream, outputStream);
-        }
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            await OutputClearSignedAsync(inputStream, outputStream);
-        }
-
-        #endregion ClearSignStreamAsync
-        #region ClearSignStream
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void ClearSignStream(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            ClearSignStream(inputStream, outputStream);
-        }
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void ClearSignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            ClearSignStream(inputStream, outputStream);
-        }
-
-        /// <summary>
-        /// Clear sign the provided stream
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be signed</param>
-        /// <param name="outputStream">Output PGP signed stream</param>
-        public void ClearSignStream(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            OutputClearSigned(inputStream, outputStream);
-        }
-
-        #endregion ClearSignStream
-        #region ClearSignArmoredStringAsync
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task<string> ClearSignArmoredStringAsync(string input, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await ClearSignStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<string> ClearSignArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await ClearSignStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        public async Task<string> ClearSignArmoredStringAsync(string input)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await ClearSignStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion ClearSignArmoredStringAsync
-        #region ClearSignArmoredString
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public string ClearSignArmoredString(string input, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                ClearSignStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public string ClearSignArmoredString(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                ClearSignStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// Clear sign the provided string
-        /// </summary>
-        /// <param name="input">Plain string to be signed</param>
-        public string ClearSignArmoredString(string input)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                ClearSignStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion ClearSignArmoredString
-        #endregion ClearSign
-
-        #region Decrypt
-        #region DecryptFileAsync
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task DecryptFileAsync(string inputFilePath, string outputFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            await DecryptFileAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task DecryptFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptFileAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        public async Task DecryptFileAsync(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream outStream = File.Create(outputFilePath))
-                await DecryptStreamAsync(inputStream, outStream);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            await DecryptFileAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptFileAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-            using (Stream outStream = outputFile.OpenWrite())
-                await DecryptStreamAsync(inputStream, outStream);
-        }
-
-        #endregion DecryptFileAsync
-        #region DecryptFile
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void DecryptFile(string inputFilePath, string outputFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
-            DecryptFile(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void DecryptFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptFile(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <param name="outputFilePath">Output PGP decrypted file path</param>
-        public void DecryptFile(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream outStream = File.Create(outputFilePath))
-                Decrypt(inputStream, outStream);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void DecryptFile(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
-            DecryptFile(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void DecryptFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptFile(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file</param>
-        /// <param name="outputFile">Output PGP decrypted file</param>
-        public void DecryptFile(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-            using (Stream outStream = outputFile.OpenWrite())
-                DecryptStream(inputStream, outStream);
-        }
-
-        #endregion DecryptFile
-        #region DecryptStreamAsync
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            await DecryptStreamAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptStreamAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            await DecryptAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        #endregion DecryptStreamAsync
-        #region DecryptStream
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public Stream DecryptStream(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
-            DecryptStream(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public Stream DecryptStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptStream(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        public Stream DecryptStream(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            Decrypt(inputStream, outputStream);
-            return outputStream;
-        }
-
-        #endregion DecryptStream
-        #region DecryptArmoredStringAsync
-        /// <summary>
-        /// PGP decrypt a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted data stream</param>
-        /// <param name="privateKey">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task<string> DecryptArmoredStringAsync(string input, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<string> DecryptArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string</param>
-        public async Task<string> DecryptArmoredStringAsync(string input)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion DecryptArmoredStringAsync
-        #region DecryptArmoredString
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="input">PGP encrypted data stream</param>
-        /// <param name="privateKey">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public string DecryptArmoredString(string input, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public string DecryptArmoredString(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string</param>
-        public string DecryptArmoredString(string input)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStream(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion DecryptArmoredString
-        #endregion Decrypt
-
-        #region DecryptAndVerify
-        #region DecryptFileAndVerifyAsync
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath, string publicKeyFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath), passPhrase);
-            await DecryptFileAndVerifyAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptFileAndVerifyAsync(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream outStream = File.Create(outputFilePath))
-                await DecryptStreamAndVerifyAsync(inputStream, outStream);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
-        /// <param name="outputFile">Output PGP decrypted and verified file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
-            await DecryptFileAndVerifyAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
-        /// <param name="outputFile">Output PGP decrypted and verified file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptFileAndVerifyAsync(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-            using (Stream outStream = outputFile.OpenWrite())
-                await DecryptStreamAndVerifyAsync(inputStream, outStream);
-        }
-
-        #endregion DecryptFileAndVerifyAsync
-        #region DecryptFileAndVerify
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        /// <param name="privateKeyFilePath">PGP secret key file path</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void DecryptFileAndVerify(string inputFilePath, string outputFilePath, string publicKeyFilePath, string privateKeyFilePath, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath), passPhrase);
-            DecryptFileAndVerify(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void DecryptFileAndVerify(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptFileAndVerify(inputFilePath, outputFilePath);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        public void DecryptFileAndVerify(string inputFilePath, string outputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (String.IsNullOrEmpty(outputFilePath))
-                throw new ArgumentException("OutputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-            using (Stream outStream = File.Create(outputFilePath))
-                DecryptAndVerify(inputStream, outStream);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
-        /// <param name="outputFile">Output PGP decrypted and verified file</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        /// <param name="privateKeyFile">PGP secret key file</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile, FileInfo privateKeyFile, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
-            DecryptFileAndVerify(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
-        /// <param name="outputFile">Output PGP decrypted and verified file</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptFileAndVerify(inputFile, outputFile);
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
-        /// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
-        public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (outputFile == null)
-                throw new ArgumentException("OutputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-            using (Stream outStream = outputFile.OpenWrite())
-                DecryptStreamAndVerify(inputStream, outStream);
-        }
-
-        #endregion DecryptFileAndVerify
-        #region DecryptStreamAndVerifyAsync
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream, Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
-            await DecryptStreamAndVerifyAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
-        public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            await DecryptStreamAndVerifyAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            await DecryptAndVerifyAsync(inputStream, outputStream);
-            return outputStream;
-        }
-
-        #endregion DecryptStreamAndVerifyAsync
-        #region DecryptStreamAndVerify
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        /// <param name="privateKeyStream">PGP secret key stream</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream, Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
-            DecryptStreamAndVerify(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            DecryptStreamAndVerify(inputStream, outputStream);
-            return outputStream;
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            DecryptAndVerify(inputStream, outputStream);
-            return outputStream;
-        }
-
-        #endregion DecryptStreamAndVerify
-        #region DecryptArmoredStringAndVerifyAsync
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public async Task<string> DecryptArmoredStringAndVerifyAsync(string input, string publicKey, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync(), await privateKey.GetStreamAsync(), passPhrase);
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAndVerifyAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
-        public async Task<string> DecryptArmoredStringAndVerifyAsync(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAndVerifyAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        public async Task<string> DecryptArmoredStringAndVerifyAsync(string input)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                await DecryptStreamAndVerifyAsync(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return await outputStream.GetStringAsync();
-            }
-        }
-        #endregion DecryptArmoredStringAndVerifyAsync
-        #region DecryptArmoredStringAndVerify
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        /// <param name="publicKey">PGP public key</param>
-        /// <param name="privateKey">PGP secret key</param>
-        /// <param name="passPhrase">PGP secret key password</param>
-        public string DecryptArmoredStringAndVerify(string input, string publicKey, string privateKey, string passPhrase)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKey.GetStream(), privateKey.GetStream(), passPhrase);
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStreamAndVerify(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
-        public string DecryptArmoredStringAndVerify(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStreamAndVerify(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-
-        /// <summary>
-        /// PGP decrypt and verify a given string.
-        /// </summary>
-        /// <param name="input">PGP encrypted string to be decrypted and verified</param>
-        public string DecryptArmoredStringAndVerify(string input)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                DecryptStreamAndVerify(inputStream, outputStream);
-                outputStream.Seek(0, SeekOrigin.Begin);
-                return outputStream.GetString();
-            }
-        }
-        #endregion DecryptArmoredStringAndVerify
-        #region VerifyFileAsync
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        public async Task<bool> VerifyFileAsync(string inputFilePath, string publicKeyFilePath)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            return await VerifyFileAsync(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        public async Task<bool> VerifyFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyFileAsync(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        public async Task<bool> VerifyFileAsync(string inputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-                return await VerifyAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        public async Task<bool> VerifyFileAsync(FileInfo inputFile, FileInfo publicKeyFile)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            return await VerifyFileAsync(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        public async Task<bool> VerifyFileAsync(FileInfo inputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyFileAsync(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        public async Task<bool> VerifyFileAsync(FileInfo inputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-                return await VerifyAsync(inputStream);
-        }
-
-        #endregion VerifyFileAsync
-        #region VerifyFile
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        public bool VerifyFile(string inputFilePath, string publicKeyFilePath)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            return VerifyFile(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyFile(string inputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return VerifyFile(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        public bool VerifyFile(string inputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-                return Verify(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        public bool VerifyFile(FileInfo inputFile, FileInfo publicKeyFile)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            return VerifyFile(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
-        public bool VerifyFile(FileInfo inputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return VerifyFile(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        public bool VerifyFile(FileInfo inputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentException("EncryptionKeys");
-
-            if (!inputFile.Exists)
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFile.FullName));
-
-            using (Stream inputStream = inputFile.OpenRead())
-                return Verify(inputStream);
-        }
-
-        #endregion VerifyFile
-        #region VerifyStreamAsync
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        public async Task<bool> VerifyStreamAsync(Stream inputStream, Stream publicKeyStream)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            return await VerifyStreamAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyStreamAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        public async Task<bool> VerifyStreamAsync(Stream inputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            return await VerifyAsync(inputStream);
-        }
-
-        #endregion VerifyStreamAsync
-        #region VerifyStream
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        public bool VerifyStream(Stream inputStream, Stream publicKeyStream)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            return Verify(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyStream(Stream inputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return Verify(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">Plain data stream to be verified</param>
-        public bool VerifyStream(Stream inputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            return Verify(inputStream);
-        }
-
-        #endregion VerifyStream
-        #region VerifyArmoredStringAsync
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        /// <param name="publicKey">PGP public key stream</param>
-        public async Task<bool> VerifyArmoredStringAsync(string input, string publicKey)
-        {
-            EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyStreamAsync(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyStreamAsync(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        public async Task<bool> VerifyArmoredStringAsync(string input)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyStreamAsync(inputStream);
-            }
-        }
-        #endregion VerifyArmoredStringAsync
-        #region VerifyArmoredString
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        /// <param name="publicKey">PGP public key</param>
-        public bool VerifyArmoredString(string input, string publicKey)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyStream(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyArmoredString(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyStream(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given string.
-        /// </summary>
-        /// <param name="input">Plain string to be verified</param>
-        public bool VerifyArmoredString(string input)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyStream(inputStream);
-            }
-        }
-        #endregion VerifyArmoredString
-        #region VerifyClearFileAsync
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        public async Task<bool> VerifyClearFileAsync(string inputFilePath, string publicKeyFilePath)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            return await VerifyClearFileAsync(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyClearFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyClearFileAsync(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        public async Task<bool> VerifyClearFileAsync(string inputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-                return await VerifyClearAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        public async Task<bool> VerifyClearFileAsync(FileInfo inputFile, FileInfo publicKeyFile)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            return await VerifyClearFileAsync(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyClearFileAsync(FileInfo inputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyClearFileAsync(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        public async Task<bool> VerifyClearFileAsync(FileInfo inputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-
-            using (Stream inputStream = inputFile.OpenRead())
-                return await VerifyClearAsync(inputStream);
-        }
-
-        #endregion VerifyClearFileAsync
-        #region VerifyClearFile
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="publicKeyFilePath">PGP public key file path</param>
-        public bool VerifyClearFile(string inputFilePath, string publicKeyFilePath)
-        {
-            EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
-            return VerifyClearFile(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyClearFile(string inputFilePath, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return VerifyClearFile(inputFilePath);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFilePath">Plain data file path to be verified</param>
-        public bool VerifyClearFile(string inputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("Encryption Key not found.");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-                return VerifyClear(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="publicKeyFile">PGP public key file</param>
-        public bool VerifyClearFile(FileInfo inputFile, FileInfo publicKeyFile)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyFile);
-            return VerifyClearFile(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyClearFile(FileInfo inputFile, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return VerifyClearFile(inputFile);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed file.
-        /// </summary>
-        /// <param name="inputFile">Plain data file to be verified</param>
-        public bool VerifyClearFile(FileInfo inputFile)
-        {
-            if (inputFile == null)
-                throw new ArgumentException("InputFile");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-
-            using (Stream inputStream = inputFile.OpenRead())
-                return VerifyClear(inputStream);
-        }
-
-        #endregion VerifyClearFile
-        #region VerifyClearStreamAsync
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed data stream to be verified</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        public async Task<bool> VerifyClearStreamAsync(Stream inputStream, Stream publicKeyStream)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            return await VerifyClearStreamAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed data stream to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyClearStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return await VerifyClearStreamAsync(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed data stream to be verified</param>
-        public async Task<bool> VerifyClearStreamAsync(Stream inputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            return await VerifyClearAsync(inputStream);
-        }
-
-        #endregion VerifyClearStreamAsync
-        #region VerifyClearStream
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed stream to be verified</param>
-        /// <param name="publicKeyStream">PGP public key stream</param>
-        public bool VerifyClearStream(Stream inputStream, Stream publicKeyStream)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKeyStream);
-            return VerifyClearStream(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed stream to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyClearStream(Stream inputStream, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-            return VerifyClearStream(inputStream);
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed stream.
-        /// </summary>
-        /// <param name="inputStream">Clear signed stream to be verified</param>
-        public bool VerifyClearStream(Stream inputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (EncryptionKeys == null)
-                throw new ArgumentNullException("EncryptionKeys");
-            if (inputStream.Position != 0)
-                throw new ArgumentException("inputStream should be at start of stream");
-
-            return VerifyClear(inputStream);
-        }
-
-        #endregion VerifyClearStream
-        #region VerifyClearArmoredStringAsync
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="publicKey">PGP public key</param>
-        public async Task<bool> VerifyClearArmoredStringAsync(string input, string publicKey)
-        {
-            EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyClearStreamAsync(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public async Task<bool> VerifyClearArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyClearStreamAsync(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        public async Task<bool> VerifyClearArmoredStringAsync(string input)
-        {
-            using (Stream inputStream = await input.GetStreamAsync())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return await VerifyClearStreamAsync(inputStream);
-            }
-        }
-        #endregion VerifyClearArmoredStringAsync
-        #region VerifyClearArmoredString
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="publicKey">PGP public key</param>
-        public bool VerifyClearArmoredString(string input, string publicKey)
-        {
-            EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyClearStream(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        /// <param name="encryptionKeys">Encryption keys</param>
-        public bool VerifyClearArmoredString(string input, IEncryptionKeys encryptionKeys)
-        {
-            EncryptionKeys = encryptionKeys;
-
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyClearStream(inputStream);
-            }
-        }
-
-        /// <summary>
-        /// PGP verify a given clear signed string.
-        /// </summary>
-        /// <param name="input">Clear signed string to be verified</param>
-        public bool VerifyClearArmoredString(string input)
-        {
-            using (Stream inputStream = input.GetStream())
-            using (Stream outputStream = new MemoryStream())
-            {
-                return VerifyClearStream(inputStream);
-            }
-        }
-        #endregion VerifyClearArmoredString
-        #endregion DecryptAndVerify
-
-        #region GetRecipients
-
-        /// <summary>
-        /// PGP get a recipients keys id of an encrypted file.
-        /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
-        /// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
-        public IEnumerable<long> GetFileRecipients(string inputFilePath)
-        {
-            if (String.IsNullOrEmpty(inputFilePath))
-                throw new ArgumentException("InputFilePath");
-
-            if (!File.Exists(inputFilePath))
-                throw new FileNotFoundException(String.Format("Encrypted File [{0}] not found.", inputFilePath));
-
-            using (Stream inputStream = File.OpenRead(inputFilePath))
-                return GetStreamRecipients(inputStream);
-        }
-
-        /// <summary>
-        /// PGP get a recipients keys id of an encrypted stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
-        public IEnumerable<long> GetStreamRecipients(Stream inputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-
-            PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-
-            PgpObject obj = null;
-            if (objFactory != null)
-                obj = objFactory.NextPgpObject();
-
-            // the first object might be a PGP marker packet.
-            PgpEncryptedDataList enc = null;
-
-            if (obj is PgpEncryptedDataList list)
-                enc = list;
-            else
-                enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
-
-            // If enc is null at this point, we failed to detect the contents of the encrypted stream.
-            if (enc == null)
-                throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
-
-            // Return keys id
-            return enc.GetEncryptedDataObjects().OfType<PgpPublicKeyEncryptedData>().Select(k => k.KeyId);
-        }
-
-        /// <summary>
-        /// PGP get a recipients keys id of an encrypted file.
-        /// </summary>
-        /// <param name="input">PGP encrypted string</param>
-        /// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
-        public IEnumerable<long> GetArmoredStringRecipients(string input)
-        {
-            if (String.IsNullOrEmpty(input))
-                throw new ArgumentException("Input");
-
-            using (Stream inputStream = input.GetStream())
-                return GetStreamRecipients(inputStream);
-        }
-
-        #endregion GetRecipients
-
-        #region GenerateKey
-
-        public async Task GenerateKeyAsync(string publicKeyFilePath, string privateKeyFilePath, string username = null, string password = null, int strength = 1024, int certainty = 8, bool emitVersion = true)
-        {
-            await Task.Run(() => GenerateKey(publicKeyFilePath, privateKeyFilePath, username, password, strength, certainty, emitVersion));
-        }
-
-        public void GenerateKey(string publicKeyFilePath, string privateKeyFilePath, string username = null, string password = null, int strength = 1024, int certainty = 8, bool emitVersion = true)
-        {
-            if (String.IsNullOrEmpty(publicKeyFilePath))
-                throw new ArgumentException("PublicKeyFilePath");
-            if (String.IsNullOrEmpty(privateKeyFilePath))
-                throw new ArgumentException("PrivateKeyFilePath");
-
-            using (Stream pubs = File.Open(publicKeyFilePath, FileMode.Create))
-            using (Stream pris = File.Open(privateKeyFilePath, FileMode.Create))
-                GenerateKey(pubs, pris, username, password, strength, certainty, emitVersion: emitVersion);
-        }
-
-        public void GenerateKey(Stream publicKeyStream, Stream privateKeyStream, string username = null, string password = null, int strength = 1024, int certainty = 8, bool armor = true, bool emitVersion = true)
-        {
-            username = username == null ? string.Empty : username;
-            password = password == null ? string.Empty : password;
-
-            IAsymmetricCipherKeyPairGenerator kpg = new RsaKeyPairGenerator();
-            kpg.Init(new RsaKeyGenerationParameters(BigInteger.ValueOf(0x13), new SecureRandom(), strength, certainty));
-            AsymmetricCipherKeyPair kp = kpg.GenerateKeyPair();
-
-            ExportKeyPair(privateKeyStream, publicKeyStream, kp.Public, kp.Private, username, password.ToCharArray(), armor, emitVersion);
-        }
-
-        #endregion GenerateKey
-
-        #region Private helpers
-        #region OutputEncryptedAsync
-
-        private async Task OutputEncryptedAsync(string inputFilePath, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            await OutputEncryptedAsync(new FileInfo(inputFilePath), outputStream, withIntegrityCheck, name);
-        }
-
-        private async Task OutputEncryptedAsync(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
-            {
-                using (Stream compressedOut = ChainCompressedOut(encryptedOut))
-                {
-                    PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                    using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
-                    {
-                        using (FileStream inputFileStream = inputFile.OpenRead())
-                        {
-                            await WriteOutputAndSignAsync(compressedOut, literalOut, inputFileStream, signatureGenerator);
-                        }
-                    }
-                }
-            }
-        }
-
-        private async Task OutputEncryptedAsync(Stream inputStream, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
-            {
-                using (Stream compressedOut = ChainCompressedOut(encryptedOut))
-                {
-                    PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                    using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
-                    {
-                        await WriteOutputAndSignAsync(compressedOut, literalOut, inputStream, signatureGenerator);
-                    }
-                }
-            }
-        }
-
-        #endregion OutputEncryptedAsync
-        #region OutputEncrypted
-
-        private void OutputEncrypted(string inputFilePath, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            OutputEncrypted(new FileInfo(inputFilePath), outputStream, withIntegrityCheck, name);
-        }
-
-        private void OutputEncrypted(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
-            {
-                using (Stream compressedOut = ChainCompressedOut(encryptedOut))
-                {
-                    PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                    using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
-                    {
-                        using (FileStream inputFileStream = inputFile.OpenRead())
-                        {
-                            WriteOutputAndSign(compressedOut, literalOut, inputFileStream, signatureGenerator);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void OutputEncrypted(Stream inputStream, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
-            {
-                using (Stream compressedOut = ChainCompressedOut(encryptedOut))
-                {
-                    PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                    using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
-                    {
-                        WriteOutputAndSign(compressedOut, literalOut, inputStream, signatureGenerator);
-                    }
-                }
-            }
-        }
-
-        #endregion OutputEncrypted
-        #region OutputSignedAsync
-
-        private async Task OutputSignedAsync(string inputFilePath, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            await OutputSignedAsync(new FileInfo(inputFilePath), outputStream, withIntegrityCheck, name);
-        }
-
-        private async Task OutputSignedAsync(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream compressedOut = ChainCompressedOut(outputStream))
-            {
-                PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
-                {
-                    using (FileStream inputFileStream = inputFile.OpenRead())
-                    {
-                        await WriteOutputAndSignAsync(compressedOut, literalOut, inputFileStream, signatureGenerator);
-                    }
-                }
-            }
-        }
-
-        private async Task OutputSignedAsync(Stream inputStream, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream compressedOut = ChainCompressedOut(outputStream))
-            {
-                PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
-                {
-                    await WriteOutputAndSignAsync(compressedOut, literalOut, inputStream, signatureGenerator);
-                }
-            }
-        }
-
-        #endregion OutputSignedAsync
-        #region OutputSigned
-
-        private void OutputSigned(string inputFilePath, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            OutputSigned(new FileInfo(inputFilePath), outputStream, withIntegrityCheck, name);
-        }
-
-        private void OutputSigned(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream compressedOut = ChainCompressedOut(outputStream))
-            {
-                PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
-                {
-                    using (FileStream inputFileStream = inputFile.OpenRead())
-                    {
-                        WriteOutputAndSign(compressedOut, literalOut, inputFileStream, signatureGenerator);
-                    }
-                }
-            }
-        }
-
-        private void OutputSigned(Stream inputStream, Stream outputStream, bool withIntegrityCheck, string name)
-        {
-            using (Stream compressedOut = ChainCompressedOut(outputStream))
-            {
-                PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
-                using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
-                {
-                    WriteOutputAndSign(compressedOut, literalOut, inputStream, signatureGenerator);
-                }
-            }
-        }
-
-        #endregion OutputSigned
-        #region OutputClearSignedAsync
-
-        private async Task OutputClearSignedAsync(string inputFilePath, Stream outputStream)
-        {
-            await OutputClearSignedAsync(new FileInfo(inputFilePath), outputStream);
-        }
-
-        private async Task OutputClearSignedAsync(FileInfo inputFile, Stream outputStream)
-        {
-            using (FileStream inputFileStream = inputFile.OpenRead())
-            {
-                await OutputClearSignedAsync(inputFileStream, outputStream);
-            }
-        }
-
-        private async Task OutputClearSignedAsync(Stream inputStream, Stream outputStream)
-        {
-            using (StreamReader streamReader = new StreamReader(inputStream))
-            using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-            {
-                PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
-
-                while (streamReader.Peek() >= 0)
-                {
-                    string line = await streamReader.ReadLineAsync();
-                    byte[] lineByteArray = Encoding.ASCII.GetBytes(line);
-                    // Does the line end with whitespace?
-                    // Trailing white space needs to be removed from the end of the document for a valid signature RFC 4880 Section 7.1
-                    string cleanLine = line.TrimEnd();
-                    byte[] cleanLineByteArray = Encoding.ASCII.GetBytes(cleanLine);
-
-                    pgpSignatureGenerator.Update(cleanLineByteArray, 0, cleanLineByteArray.Length);
-                    await armoredOutputStream.WriteAsync(lineByteArray, 0, lineByteArray.Length);
-
-                    // Add a line break back to the stream
-                    armoredOutputStream.Write((byte)'\r');
-                    armoredOutputStream.Write((byte)'\n');
-
-                    // Update signature with line breaks unless we're on the last line
-                    if (streamReader.Peek() >= 0)
-                    {
-                        pgpSignatureGenerator.Update((byte)'\r');
-                        pgpSignatureGenerator.Update((byte)'\n');
-                    }
-                }
-
-                armoredOutputStream.EndClearText();
-
-                BcpgOutputStream bcpgOutputStream = new BcpgOutputStream(armoredOutputStream);
-                pgpSignatureGenerator.Generate().Encode(bcpgOutputStream);
-            }
-        }
-
-        #endregion OutputClearSignedAsync
-        #region OutputClearSigned
-
-        private void OutputClearSigned(string inputFilePath, Stream outputStream)
-        {
-            OutputClearSigned(new FileInfo(inputFilePath), outputStream);
-        }
-
-        private void OutputClearSigned(FileInfo inputFile, Stream outputStream)
-        {
-            using (FileStream inputFileStream = inputFile.OpenRead())
-            {
-                OutputClearSigned(inputFileStream, outputStream);
-            }
-        }
-
-        private void OutputClearSigned(Stream inputStream, Stream outputStream)
-        {
-            using (StreamReader streamReader = new StreamReader(inputStream))
-            using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
-            {
-                PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
-
-                while (streamReader.Peek() >= 0)
-                {
-                    string line = streamReader.ReadLine();
-                    byte[] lineByteArray = Encoding.ASCII.GetBytes(line);
-                    // Does the line end with whitespace?
-                    // Trailing white space needs to be removed from the end of the document for a valid signature RFC 4880 Section 7.1
-                    string cleanLine = line.TrimEnd();
-                    byte[] cleanLineByteArray = Encoding.ASCII.GetBytes(cleanLine);
-
-                    pgpSignatureGenerator.Update(cleanLineByteArray, 0, cleanLineByteArray.Length);
-                    armoredOutputStream.Write(lineByteArray, 0, lineByteArray.Length);
-
-                    // Add a line break back to the stream
-                    armoredOutputStream.Write((byte)'\r');
-                    armoredOutputStream.Write((byte)'\n');
-
-                    // Update signature with line breaks unless we're on the last line
-                    if (streamReader.Peek() >= 0)
-                    {
-                        pgpSignatureGenerator.Update((byte)'\r');
-                        pgpSignatureGenerator.Update((byte)'\n');
-                    }
-                }
-
-                armoredOutputStream.EndClearText();
-
-                BcpgOutputStream bcpgOutputStream = new BcpgOutputStream(armoredOutputStream);
-                pgpSignatureGenerator.Generate().Encode(bcpgOutputStream);
-            }
-        }
-
-        #endregion OutputClearSigned
-        #region DecryptAsync
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <returns></returns>
-        private async Task DecryptAsync(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-
-            PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-
-            PgpObject obj = null;
-            if (objFactory != null)
-                obj = objFactory.NextPgpObject();
-
-            // the first object might be a PGP marker packet.
-            PgpEncryptedDataList enc = null;
-            PgpObject message = null;
-
-            if (obj is PgpEncryptedDataList)
-                enc = (PgpEncryptedDataList)obj;
-            else if (obj is PgpCompressedData)
-                message = (PgpCompressedData)obj;
-            else
-                enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
-
-            // If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
-            if (enc == null && message == null)
-                throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
-
-            // decrypt
-            PgpPrivateKey privateKey = null;
-            PgpPublicKeyEncryptedData pbe = null;
-            if (enc != null)
-            {
-                foreach (PgpPublicKeyEncryptedData pked in enc.GetEncryptedDataObjects())
-                {
-                    privateKey = EncryptionKeys.FindSecretKey(pked.KeyId);
-
-                    if (privateKey != null)
-                    {
-                        pbe = pked;
-                        break;
-                    }
-                }
-
-                if (privateKey == null)
-                    throw new ArgumentException("Secret key for message not found.");
-
-                PgpObjectFactory plainFact = null;
-
-                using (Stream clear = pbe.GetDataStream(privateKey))
-                {
-                    plainFact = new PgpObjectFactory(clear);
-                }
-
-                message = plainFact.NextPgpObject();
-
-                if (message is PgpOnePassSignatureList)
-                {
-                    message = plainFact.NextPgpObject();
-                }
-            }
-
-            if (message is PgpCompressedData)
-            {
-                PgpCompressedData cData = (PgpCompressedData)message;
-                PgpObjectFactory of = null;
-
-                using (Stream compDataIn = cData.GetDataStream())
-                {
-                    of = new PgpObjectFactory(compDataIn);
-                    message = of.NextPgpObject();
-                }
-
-                if (message is PgpOnePassSignatureList)
-                {
-                    message = of.NextPgpObject();
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    await Streams.PipeAllAsync(unc, outputStream);
-                }
-                else
-                {
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    await Streams.PipeAllAsync(unc, outputStream);
-                }
-            }
-            else if (message is PgpLiteralData)
-            {
-                PgpLiteralData ld = (PgpLiteralData)message;
-                string outFileName = ld.FileName;
-
-                Stream unc = ld.GetInputStream();
-                await Streams.PipeAllAsync(unc, outputStream);
-
-                if (pbe.IsIntegrityProtected())
-                {
-                    if (!pbe.Verify())
-                    {
-                        throw new PgpException("Message failed integrity check.");
-                    }
-                }
-            }
-            else if (message is PgpOnePassSignatureList)
-                throw new PgpException("Encrypted message contains a signed message - not literal data.");
-            else
-                throw new PgpException("Message is not a simple encrypted file.");
-        }
-
-        #endregion DecryptAsync
-        #region Decrypt
-
-        /// <summary>
-        /// PGP decrypt a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream</param>
-        /// <param name="outputStream">Output PGP decrypted stream</param>
-        /// <returns></returns>
-        private void Decrypt(Stream inputStream, Stream outputStream)
-        {
-            if (inputStream == null)
-                throw new ArgumentException("InputStream");
-            if (outputStream == null)
-                throw new ArgumentException("OutputStream");
-
-            PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-
-            PgpObject obj = null;
-            if (objFactory != null)
-                obj = objFactory.NextPgpObject();
-
-            // the first object might be a PGP marker packet.
-            PgpEncryptedDataList enc = null;
-            PgpObject message = null;
-
-            if (obj is PgpEncryptedDataList)
-                enc = (PgpEncryptedDataList)obj;
-            else if (obj is PgpCompressedData)
-                message = (PgpCompressedData)obj;
-            else
-                enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
-
-            // If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
-            if (enc == null && message == null)
-                throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
-
-            // decrypt
-            PgpPrivateKey privateKey = null;
-            PgpPublicKeyEncryptedData pbe = null;
-            if (enc != null)
-            {
-                foreach (PgpPublicKeyEncryptedData pked in enc.GetEncryptedDataObjects())
-                {
-                    privateKey = EncryptionKeys.FindSecretKey(pked.KeyId);
-
-                    if (privateKey != null)
-                    {
-                        pbe = pked;
-                        break;
-                    }
-                }
-
-                if (privateKey == null)
-                    throw new ArgumentException("Secret key for message not found.");
-
-                PgpObjectFactory plainFact = null;
-
-                using (Stream clear = pbe.GetDataStream(privateKey))
-                {
-                    plainFact = new PgpObjectFactory(clear);
-                }
-
-                message = plainFact.NextPgpObject();
-
-                if (message is PgpOnePassSignatureList)
-                {
-                    message = plainFact.NextPgpObject();
-                }
-            }
-
-            if (message is PgpCompressedData)
-            {
-                PgpCompressedData cData = (PgpCompressedData)message;
-                PgpObjectFactory of = null;
-
-                using (Stream compDataIn = cData.GetDataStream())
-                {
-                    of = new PgpObjectFactory(compDataIn);
-                    message = of.NextPgpObject();
-                }
-                
-                if (message is PgpOnePassSignatureList)
-                {
-                    message = of.NextPgpObject();
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    Streams.PipeAll(unc, outputStream);
-                }
-                else
-                {
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    Streams.PipeAll(unc, outputStream);
-                }
-            }
-            else if (message is PgpLiteralData)
-            {
-                PgpLiteralData ld = (PgpLiteralData)message;
-                string outFileName = ld.FileName;
-
-                Stream unc = ld.GetInputStream();
-                Streams.PipeAll(unc, outputStream);
-
-                if (pbe.IsIntegrityProtected())
-                {
-                    if (!pbe.Verify())
-                    {
-                        throw new PgpException("Message failed integrity check.");
-                    }
-                }
-            }
-            else if (message is PgpOnePassSignatureList)
-                throw new PgpException("Encrypted message contains a signed message - not literal data.");
-            else
-                throw new PgpException("Message is not a simple encrypted file.");
-        }
-
-        #endregion Decrypt
-        #region DecryptAndVerifyAsync
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        private async Task DecryptAndVerifyAsync(Stream inputStream, Stream outputStream)
-        {
-            PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-
-            PgpObject obj = null;
-            if (objFactory != null)
-                obj = objFactory.NextPgpObject();
-
-            // the first object might be a PGP marker packet.
-            PgpEncryptedDataList encryptedDataList = null;
-            PgpObject message = null;
-
-            if (obj is PgpEncryptedDataList)
-                encryptedDataList = (PgpEncryptedDataList)obj;
-            else if (obj is PgpCompressedData)
-                message = (PgpCompressedData)obj;
-            else
-                encryptedDataList = (PgpEncryptedDataList)objFactory.NextPgpObject();
-
-            // If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
-            if (encryptedDataList == null && message == null)
-                throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
-
-            // decrypt
-            PgpPrivateKey privateKey = null;
-            PgpPublicKeyEncryptedData pbe = null;
-            if (encryptedDataList != null)
-            {
-                foreach (PgpPublicKeyEncryptedData pked in encryptedDataList.GetEncryptedDataObjects())
-                {
-                    privateKey = EncryptionKeys.FindSecretKey(pked.KeyId);
-
-                    if (privateKey != null)
-                    {
-                        pbe = pked;
-                        break;
-                    }
-                }
-
-                if (privateKey == null)
-                    throw new ArgumentException("Secret key for message not found.");
-
-                PgpObjectFactory plainFact = null;
-
-                using (Stream clear = pbe.GetDataStream(privateKey))
-                {
-                    plainFact = new PgpObjectFactory(clear);
-                }
-
-                message = plainFact.NextPgpObject();
-
-                if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
-                {
-                    PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-
-                    var verified = EncryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || EncryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
-                    if (verified == false)
-                        throw new PgpException("Failed to verify file.");
-
-                    message = plainFact.NextPgpObject();
-                }
-                else if (!(message is PgpCompressedData))
-                    throw new PgpException("File was not signed.");
-            }
-
-            if (message is PgpCompressedData cData)
-            {
-                PgpObjectFactory of = null;
-
-                using (Stream compDataIn = cData.GetDataStream())
-                {
-                    of = new PgpObjectFactory(compDataIn);
-                    message = of.NextPgpObject();
-                }
-
-                if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
-                {
-                    PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-
-                    var verified = EncryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || EncryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
-                    if (verified == false)
-                        throw new PgpException("Failed to verify file.");
-
-                    message = of.NextPgpObject();
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    await Streams.PipeAllAsync(unc, outputStream);
-                }
-                else
-                {
-                    throw new PgpException("File was not signed.");
-                }
-            }
-            else if (message is PgpLiteralData)
-            {
-                PgpLiteralData ld = (PgpLiteralData)message;
-                string outFileName = ld.FileName;
-
-                Stream unc = ld.GetInputStream();
-                await Streams.PipeAllAsync(unc, outputStream);
-
-                if (pbe.IsIntegrityProtected())
-                {
-                    if (!pbe.Verify())
-                    {
-                        throw new PgpException("Message failed integrity check.");
-                    }
-                }
-            }
-            else
-                throw new PgpException("File was not signed.");
-        }
-
-        #endregion DecryptAndVerifyAsync
-        #region DecryptAndVerify
-
-        /// <summary>
-        /// PGP decrypt and verify a given stream.
-        /// </summary>
-        /// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
-        /// <param name="outputStream">Output PGP decrypted and verified stream</param>
-        private void DecryptAndVerify(Stream inputStream, Stream outputStream)
-        {
-            PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
-
-            PgpObject obj = null;
-            if (objFactory != null)
-                obj = objFactory.NextPgpObject();
-
-            // the first object might be a PGP marker packet.
-            PgpEncryptedDataList encryptedDataList = null;
-            PgpObject message = null;
-
-            if (obj is PgpEncryptedDataList)
-                encryptedDataList = (PgpEncryptedDataList)obj;
-            else if (obj is PgpCompressedData)
-                message = (PgpCompressedData)obj;
-            else
-                encryptedDataList = (PgpEncryptedDataList)objFactory.NextPgpObject();
-
-            // If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
-            if (encryptedDataList == null && message == null)
-                throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
-
-            // decrypt
-            PgpPrivateKey privateKey = null;
-            PgpPublicKeyEncryptedData pbe = null;
-            if (encryptedDataList != null)
-            {
-                foreach (PgpPublicKeyEncryptedData pked in encryptedDataList.GetEncryptedDataObjects())
-                {
-                    privateKey = EncryptionKeys.FindSecretKey(pked.KeyId);
-
-                    if (privateKey != null)
-                    {
-                        pbe = pked;
-                        break;
-                    }
-                }
-
-                if (privateKey == null)
-                    throw new ArgumentException("Secret key for message not found.");
-
-                PgpObjectFactory plainFact = null;
-
-                using (Stream clear = pbe.GetDataStream(privateKey))
-                {
-                    plainFact = new PgpObjectFactory(clear);
-                }
-
-                message = plainFact.NextPgpObject();
-
-                if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
-                {
-                    PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-
-                    var verified = EncryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || EncryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
-                    if (verified == false)
-                        throw new PgpException("Failed to verify file.");
-
-                    message = plainFact.NextPgpObject();
-                }
-                else if (!(message is PgpCompressedData))
-                    throw new PgpException("File was not signed.");
-            }
-
-            if (message is PgpCompressedData cData)
-            {
-                PgpObjectFactory of = null;
-
-                using (Stream compDataIn = cData.GetDataStream())
-                {
-                    of = new PgpObjectFactory(compDataIn);
-                    message = of.NextPgpObject();
-                }
-
-                if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
-                {
-                    PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-
-                    var verified = EncryptionKeys.PublicKey.KeyId == pgpOnePassSignature.KeyId || EncryptionKeys.PublicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
-                    if (verified == false)
-                        throw new PgpException("Failed to verify file.");
-
-                    message = of.NextPgpObject();
-                    PgpLiteralData Ld = null;
-                    Ld = (PgpLiteralData)message;
-                    Stream unc = Ld.GetInputStream();
-                    Streams.PipeAll(unc, outputStream);
-                }
-                else
-                {
-                    throw new PgpException("File was not signed.");
-                }
-            }
-            else if (message is PgpLiteralData)
-            {
-                PgpLiteralData ld = (PgpLiteralData)message;
-                string outFileName = ld.FileName;
-
-                Stream unc = ld.GetInputStream();
-                Streams.PipeAll(unc, outputStream);
-
-                if (pbe.IsIntegrityProtected())
-                {
-                    if (!pbe.Verify())
-                    {
-                        throw new PgpException("Message failed integrity check.");
-                    }
-                }
-            }
-            else
-                throw new PgpException("File was not signed.");
-        }
-
-        #endregion DecryptAndVerify
-        #region VerifyAsync
-
-        private async Task<bool> VerifyAsync(Stream inputStream)
-        {
-            PgpPublicKey publicKey = EncryptionKeys.PublicKey;
-            bool verified = false;
-
-            System.IO.Stream encodedFile = PgpUtilities.GetDecoderStream(inputStream);
-            PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
-            PgpObject pgpObject = factory.NextPgpObject();
-
-            if (pgpObject is PgpCompressedData)
-            {
-                PgpPublicKeyEncryptedData publicKeyED = Utilities.ExtractPublicKeyEncryptedData(encodedFile);
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == publicKeyED.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(publicKeyED.KeyId))
-                {
-                    verified = true;
-                }
-                else
-                {
-                    verified = false;
-                }
-            }
-            else if (pgpObject is PgpEncryptedDataList)
-            {
-                PgpEncryptedDataList encryptedDataList = (PgpEncryptedDataList)pgpObject;
-                PgpPublicKeyEncryptedData publicKeyED = Utilities.ExtractPublicKey(encryptedDataList);
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == publicKeyED.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(publicKeyED.KeyId))
-                {
-                    verified = true;
-                }
-                else
-                {
-                    verified = false;
-                }
-                //PgpEncryptedDataList encryptedDataList = (PgpEncryptedDataList)pgpObject;
-
-                //foreach (PgpPublicKeyEncryptedData encryptedData in encryptedDataList.GetEncryptedDataObjects())
-                //{
-                //    encryptedData.GetDataStream(EncryptionKeys.PrivateKey);
-                //    if (encryptedData.Verify())
-                //    {
-                //        verified = true;
-                //        break;
-                //    }
-                //}
-            }
-            else if (pgpObject is PgpOnePassSignatureList)
-            {
-                PgpOnePassSignatureList pgpOnePassSignatureList = (PgpOnePassSignatureList)pgpObject;
-                PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-                PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
-                Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == pgpOnePassSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId))
-                {
-                    pgpOnePassSignature.InitVerify(publicKey);
-
-                    int ch;
-                    while ((ch = pgpLiteralStream.ReadByte()) >= 0)
-                    {
-                        pgpOnePassSignature.Update((byte)ch);
-                    }
-
-                    try
-                    {
-                        PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
-
-                        for (int i = 0; i < pgpSignatureList.Count; i++)
-                        {
-                            PgpSignature pgpSignature = pgpSignatureList[i];
-
-                            if (pgpOnePassSignature.Verify(pgpSignature))
-                            {
-                                verified = true;
-                                break;
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        verified = false;
-                    }
-                }
-                else
-                {
-                    verified = false;
-                }
-            }
-            else if (pgpObject is PgpSignatureList)
-            {
-                PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObject;
-                PgpSignature pgpSignature = pgpSignatureList[0];
-                PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
-                Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == pgpSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpSignature.KeyId))
-                {
-                    foreach (PgpSignature signature in publicKey.GetSignatures())
-                    {
-                        if (!verified)
-                        {
-                            pgpSignature.InitVerify(publicKey);
-
-                            int ch;
-                            while ((ch = pgpLiteralStream.ReadByte()) >= 0)
-                            {
-                                pgpSignature.Update((byte)ch);
-                            }
-
-                            verified = pgpSignature.Verify();
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    verified = false;
-                }
-            }
-            else
-                throw new PgpException("Message is not a encrypted and signed file or simple signed file.");
-
-            return verified;
-        }
-
-        #endregion VerifyAsync
-        #region Verify
-
-        private bool Verify(Stream inputStream)
-        {
-            PgpPublicKey publicKey = EncryptionKeys.PublicKey;
-            bool verified = false;
-
-            ArmoredInputStream encodedFile = new ArmoredInputStream(inputStream);
-            PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
-            PgpObject pgpObject = factory.NextPgpObject();
-
-            if (pgpObject is PgpCompressedData)
-            {
-                PgpCompressedData pgpCompressedData = (PgpCompressedData)pgpObject;
-                PgpObjectFactory pgpCompressedFactory = new PgpObjectFactory(pgpCompressedData.GetDataStream());
-
-                PgpOnePassSignatureList pgpOnePassSignatureList = (PgpOnePassSignatureList)pgpCompressedFactory.NextPgpObject();
-                PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-                PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
-                Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == pgpOnePassSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId))
-                {
-                    foreach (PgpSignature signature in publicKey.GetSignatures())
-                    {
-                        if (!verified)
-                        {
-                            pgpOnePassSignature.InitVerify(publicKey);
-
-                            int ch;
-                            while ((ch = pgpLiteralStream.ReadByte()) >= 0)
-                            {
-                                pgpOnePassSignature.Update((byte)ch);
-                            }
-
-                            try
-                            {
-                                PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
-
-                                for (int i = 0; i < pgpSignatureList.Count; i++)
-                                {
-                                    PgpSignature pgpSignature = pgpSignatureList[i];
-
-                                    if (pgpOnePassSignature.Verify(pgpSignature))
-                                    {
-                                        verified = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            catch
-                            {
-                                verified = false;
-                                break;
-                            }
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    verified = false;
-                }
-            }
-            else if (pgpObject is PgpEncryptedDataList)
-            {
-                PgpEncryptedDataList encryptedDataList = (PgpEncryptedDataList)pgpObject;
-                PgpPublicKeyEncryptedData publicKeyED = Utilities.ExtractPublicKey(encryptedDataList);
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == publicKeyED.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(publicKeyED.KeyId))
-                {
-                    verified = true;
-                }
-                else
-                {
-                    verified = false;
-                }
-                //PgpEncryptedDataList encryptedDataList = (PgpEncryptedDataList)pgpObject;
-
-                //foreach (PgpPublicKeyEncryptedData encryptedData in encryptedDataList.GetEncryptedDataObjects())
-                //{
-                //    using (encryptedData.GetDataStream(EncryptionKeys.PrivateKey))
-                //    {
-                //        if (encryptedData.Verify())
-                //        {
-                //            verified = true;
-                //            break;
-                //        }
-                //    }
-                //}
-            }
-            else if (pgpObject is PgpOnePassSignatureList)
-            {
-                PgpOnePassSignatureList pgpOnePassSignatureList = (PgpOnePassSignatureList)pgpObject;
-                PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
-                PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
-                Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
-
-                // Verify against public key ID and that of any sub keys
-                if (publicKey.KeyId == pgpOnePassSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId))
-                {
-                    pgpOnePassSignature.InitVerify(publicKey);
-
-                    int ch;
-                    while ((ch = pgpLiteralStream.ReadByte()) >= 0)
-                    {
-                        pgpOnePassSignature.Update((byte)ch);
-                    }
-
-                    try
-                    {
-                        PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
-
-                        for (int i = 0; i < pgpSignatureList.Count; i++)
-                        {
-                            PgpSignature pgpSignature = pgpSignatureList[i];
-
-                            if (pgpOnePassSignature.Verify(pgpSignature))
-                            {
-                                verified = true;
-                                break;
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        verified = false;
-                    }
-                }
-                else
-                {
-                    verified = false;
-                }
-            }
-            else if (pgpObject is PgpSignatureList)
-            {
-               PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObject;
-               PgpSignature pgpSignature = pgpSignatureList[0];
-               PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
-               Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
-
-               // Verify against public key ID and that of any sub keys
-               if (publicKey.KeyId == pgpSignature.KeyId || publicKey.GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpSignature.KeyId))
-               {
-                   foreach (PgpSignature signature in publicKey.GetSignatures())
-                   {
-                       if (!verified)
-                       {
-                           pgpSignature.InitVerify(publicKey);
-
-                           int ch;
-                           while ((ch = pgpLiteralStream.ReadByte()) >= 0)
-                           {
-                               pgpSignature.Update((byte)ch);
-                           }
-
-                            verified = pgpSignature.Verify();
-                       }
-                       else
-                       {
-                           break;
-                       }
-                   }
-               }
-               else
-               {
-                   verified = false;
-               }
-            }
-            else
-                throw new PgpException("Message is not a encrypted and signed file or simple signed file.");
-
-            return verified;
-        }
-
-        #endregion Verify
-        #region VerifyClearAsync
-
-        // https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
-        private async Task<bool> VerifyClearAsync(Stream inputStream)
-        {
-            bool verified = false;
-
-            using (MemoryStream outStream = new MemoryStream())
-            {
-                var publicKey = EncryptionKeys.PublicKey;
-                PgpSignature pgpSignature;
-
-                using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))
-                {
-                    MemoryStream lineOut = new MemoryStream();
-                    byte[] lineSep = LineSeparator;
-                    int lookAhead = ReadInputLine(lineOut, armoredInputStream);
-
-                    // Read past message to signature and store message in stream
-                    if (lookAhead != -1 && armoredInputStream.IsClearText())
-                    {
-                        byte[] line = lineOut.ToArray();
-                        await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                        await outStream.WriteAsync(lineSep, 0, lineSep.Length);
-
-                        while (lookAhead != -1 && armoredInputStream.IsClearText())
-                        {
-                            lookAhead = ReadInputLine(lineOut, lookAhead, armoredInputStream);
-
-                            line = lineOut.ToArray();
-                            await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                            await outStream.WriteAsync(lineSep, 0, lineSep.Length);
-                        }
-                    }
-                    else if (lookAhead != -1)
-                    {
-                        byte[] line = lineOut.ToArray();
-                        await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                        await outStream.WriteAsync(lineSep, 0, lineSep.Length);
-                    }
-
-                    // Get public key from correctly positioned stream and initialise for verification
-                    PgpObjectFactory pgpObjectFactory = new PgpObjectFactory(armoredInputStream);
-                    PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObjectFactory.NextPgpObject();
-                    pgpSignature = pgpSignatureList[0];
-                    pgpSignature.InitVerify(publicKey);
-
-                    // Read through message again and calculate signature
-                    outStream.Position = 0;
-                    lookAhead = ReadInputLine(lineOut, outStream);
-
-                    ProcessLine(pgpSignature, lineOut.ToArray());
-
-                    if (lookAhead != -1)
-                    {
-                        do
-                        {
-                            lookAhead = ReadInputLine(lineOut, lookAhead, outStream);
-
-                            pgpSignature.Update((byte)'\r');
-                            pgpSignature.Update((byte)'\n');
-
-                            ProcessLine(pgpSignature, lineOut.ToArray());
-                        }
-                        while (lookAhead != -1);
-                    }
-
-                    verified = pgpSignature.Verify();
-                }
-            }
-
-            return verified;
-        }
-
-        #endregion VerifyClearAsync
-        #region VerifyClear
-
-        // https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
-        private bool VerifyClear(Stream inputStream)
-        {
-            bool verified = false;
-
-            using (MemoryStream outStream = new MemoryStream())
-            {
-                var publicKey = EncryptionKeys.PublicKey;
-                PgpSignature pgpSignature;
-
-                using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))
-                {
-                    MemoryStream lineOut = new MemoryStream();
-                    byte[] lineSep = LineSeparator;
-                    int lookAhead = ReadInputLine(lineOut, armoredInputStream);
-
-                    // Read past message to signature and store message in stream
-                    if (lookAhead != -1 && armoredInputStream.IsClearText())
-                    {
-                        byte[] line = lineOut.ToArray();
-                        outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                        outStream.Write(lineSep, 0, lineSep.Length);
-
-                        while (lookAhead != -1 && armoredInputStream.IsClearText())
-                        {
-                            lookAhead = ReadInputLine(lineOut, lookAhead, armoredInputStream);
-
-                            line = lineOut.ToArray();
-                            outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                            outStream.Write(lineSep, 0, lineSep.Length);
-                        }
-                    }
-                    else if (lookAhead != -1)
-                    {
-                        byte[] line = lineOut.ToArray();
-                        outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
-                        outStream.Write(lineSep, 0, lineSep.Length);
-                    }
-
-                    // Get public key from correctly positioned stream and initialise for verification
-                    PgpObjectFactory pgpObjectFactory = new PgpObjectFactory(armoredInputStream);
-                    PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObjectFactory.NextPgpObject();
-                    pgpSignature = pgpSignatureList[0];
-                    pgpSignature.InitVerify(publicKey);
-
-                    // Read through message again and calculate signature
-                    outStream.Position = 0;
-                    lookAhead = ReadInputLine(lineOut, outStream);
-
-                    ProcessLine(pgpSignature, lineOut.ToArray());
-
-                    if (lookAhead != -1)
-                    {
-                        do
-                        {
-                            lookAhead = ReadInputLine(lineOut, lookAhead, outStream);
-
-                            pgpSignature.Update((byte)'\r');
-                            pgpSignature.Update((byte)'\n');
-
-                            ProcessLine(pgpSignature, lineOut.ToArray());
-                        }
-                        while (lookAhead != -1);
-                    }
-
-                    verified = pgpSignature.Verify();
-                }
-            }
-
-            return verified;
-        }
-
-        #endregion VerifyClear
-        #region WriteOutputAndSign
-
-        private async Task WriteOutputAndSignAsync(Stream compressedOut, Stream literalOut, FileStream inputFilePath, PgpSignatureGenerator signatureGenerator)
-        {
-            int length = 0;
-            byte[] buf = new byte[BufferSize];
-            while ((length = await inputFilePath.ReadAsync(buf, 0, buf.Length)) > 0)
-            {
-                await literalOut.WriteAsync(buf, 0, length);
-                signatureGenerator.Update(buf, 0, length);
-            }
-            signatureGenerator.Generate().Encode(compressedOut);
-        }
-
-        private void WriteOutputAndSign(Stream compressedOut, Stream literalOut, FileStream inputFilePath, PgpSignatureGenerator signatureGenerator)
-        {
-            int length = 0;
-            byte[] buf = new byte[BufferSize];
-            while ((length = inputFilePath.Read(buf, 0, buf.Length)) > 0)
-            {
-                literalOut.Write(buf, 0, length);
-                signatureGenerator.Update(buf, 0, length);
-            }
-            signatureGenerator.Generate().Encode(compressedOut);
-        }
-
-        private async Task WriteOutputAndSignAsync(Stream compressedOut, Stream literalOut, Stream inputStream, PgpSignatureGenerator signatureGenerator)
-        {
-            int length = 0;
-            byte[] buf = new byte[BufferSize];
-            while ((length = await inputStream.ReadAsync(buf, 0, buf.Length)) > 0)
-            {
-                await literalOut.WriteAsync(buf, 0, length);
-                signatureGenerator.Update(buf, 0, length);
-            }
-            signatureGenerator.Generate().Encode(compressedOut);
-        }
-
-        private void WriteOutputAndSign(Stream compressedOut, Stream literalOut, Stream inputStream, PgpSignatureGenerator signatureGenerator)
-        {
-            int length = 0;
-            byte[] buf = new byte[BufferSize];
-            while ((length = inputStream.Read(buf, 0, buf.Length)) > 0)
-            {
-                literalOut.Write(buf, 0, length);
-                signatureGenerator.Update(buf, 0, length);
-            }
-            signatureGenerator.Generate().Encode(compressedOut);
-        }
-
-        #endregion WriteOutputAndSign
-        #region ChainEncryptedOut
-
-        private Stream ChainEncryptedOut(Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck)
-        {
-            PgpEncryptedDataGenerator encryptedDataGenerator;
-            encryptedDataGenerator = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-
-            foreach (PgpPublicKey publicKey in encryptionKeys.PublicKeys)
-            {
-                encryptedDataGenerator.AddMethod(publicKey);
-            }
-
-            return encryptedDataGenerator.Open(outputStream, new byte[BufferSize]);
-        }
-
-        private Stream ChainEncryptedOut(Stream outputStream, bool withIntegrityCheck)
-        {
-            PgpEncryptedDataGenerator encryptedDataGenerator;
-            encryptedDataGenerator = new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-
-            foreach (PgpPublicKey publicKey in EncryptionKeys.PublicKeys)
-            {
-                encryptedDataGenerator.AddMethod(publicKey);
-            }
-
-            return encryptedDataGenerator.Open(outputStream, new byte[BufferSize]);
-        }
-
-        #endregion ChainEncryptedOut
-        #region ChainCompressedOut
-
-        private Stream ChainCompressedOut(Stream encryptedOut)
-        {
-            if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
-            {
-                PgpCompressedDataGenerator compressedDataGenerator = new PgpCompressedDataGenerator(CompressionAlgorithmTag.Zip);
-                return compressedDataGenerator.Open(encryptedOut);
-            }
-            else
-                return encryptedOut;
-        }
-
-        #endregion ChainCompressedOut
-        #region ChainLiteralOut
-
-        private Stream ChainLiteralOut(Stream compressedOut, FileInfo file)
-        {
-            PgpLiteralDataGenerator pgpLiteralDataGenerator = new PgpLiteralDataGenerator();
-            return pgpLiteralDataGenerator.Open(compressedOut, FileTypeToChar(), file.Name, file.Length, DateTime.UtcNow);
-        }
-
-        #endregion ChainLiteralOut
-        #region ChainLiteralStreamOut
-
-        private Stream ChainLiteralStreamOut(Stream compressedOut, Stream inputStream, string name)
-        {
-            PgpLiteralDataGenerator pgpLiteralDataGenerator = new PgpLiteralDataGenerator();
-            return pgpLiteralDataGenerator.Open(compressedOut, FileTypeToChar(), name, inputStream.Length, DateTime.UtcNow);
-        }
-
-        #endregion ChainLiteralStreamOut
-        #region InitSignatureGenerator
-
-        private PgpSignatureGenerator InitSignatureGenerator(Stream compressedOut, IEncryptionKeys encryptionKeys)
-        {
-            PublicKeyAlgorithmTag tag = encryptionKeys.SecretKey.PublicKey.Algorithm;
-            PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
-            pgpSignatureGenerator.InitSign(PgpSignature.BinaryDocument, encryptionKeys.PrivateKey);
-            foreach (string userId in encryptionKeys.SecretKey.PublicKey.GetUserIds())
-            {
-                PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
-                subPacketGenerator.SetSignerUserId(false, userId);
-                pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
-                // Just the first one!
-                break;
-            }
-            pgpSignatureGenerator.GenerateOnePassVersion(false).Encode(compressedOut);
-            return pgpSignatureGenerator;
-        }
-
-        private PgpSignatureGenerator InitSignatureGenerator(Stream compressedOut)
-        {
-            PublicKeyAlgorithmTag tag = EncryptionKeys.SecretKey.PublicKey.Algorithm;
-            PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
-            pgpSignatureGenerator.InitSign(PgpSignature.BinaryDocument, EncryptionKeys.PrivateKey);
-            foreach (string userId in EncryptionKeys.SecretKey.PublicKey.GetUserIds())
-            {
-                PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
-                subPacketGenerator.SetSignerUserId(false, userId);
-                pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
-                // Just the first one!
-                break;
-            }
-            pgpSignatureGenerator.GenerateOnePassVersion(false).Encode(compressedOut);
-            return pgpSignatureGenerator;
-        }
-
-        #endregion InitSignatureGenerator
-        #region InitClearSignatureGenerator
-
-        private PgpSignatureGenerator InitClearSignatureGenerator(ArmoredOutputStream armoredOutputStream, IEncryptionKeys encryptionKeys)
-        {
-            PublicKeyAlgorithmTag tag = encryptionKeys.SecretKey.PublicKey.Algorithm;
-            PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
-            pgpSignatureGenerator.InitSign(PgpSignature.CanonicalTextDocument, encryptionKeys.PrivateKey);
-            armoredOutputStream.BeginClearText(HashAlgorithmTag);
-            foreach (string userId in encryptionKeys.SecretKey.PublicKey.GetUserIds())
-            {
-                PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
-                subPacketGenerator.SetSignerUserId(false, userId);
-                pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
-                // Just the first one!
-                break;
-            }
-            return pgpSignatureGenerator;
-        }
-
-        private PgpSignatureGenerator InitClearSignatureGenerator(ArmoredOutputStream armoredOutputStream)
-        {
-            PublicKeyAlgorithmTag tag = EncryptionKeys.SecretKey.PublicKey.Algorithm;
-            PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
-            pgpSignatureGenerator.InitSign(PgpSignature.CanonicalTextDocument, EncryptionKeys.PrivateKey);
-            armoredOutputStream.BeginClearText(HashAlgorithmTag);
-            foreach (string userId in EncryptionKeys.SecretKey.PublicKey.GetUserIds())
-            {
-                PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
-                subPacketGenerator.SetSignerUserId(false, userId);
-                pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
-                // Just the first one!
-                break;
-            }
-            return pgpSignatureGenerator;
-        }
-
-        #endregion InitClearSignatureGenerator
-        #region Misc Utilities
-        private char FileTypeToChar()
-        {
-            if (FileType == PGPFileType.UTF8)
-                return PgpLiteralData.Utf8;
-            else if (FileType == PGPFileType.Text)
-                return PgpLiteralData.Text;
-            else
-                return PgpLiteralData.Binary;
-
-        }
-
-        private void ExportKeyPair(
-                    Stream secretOut,
-                    Stream publicOut,
-                    AsymmetricKeyParameter publicKey,
-                    AsymmetricKeyParameter privateKey,
-                    string identity,
-                    char[] passPhrase,
-                    bool armor, bool emitVersion)
-        {
-            if (secretOut == null)
-                throw new ArgumentException("secretOut");
-            if (publicOut == null)
-                throw new ArgumentException("publicOut");
-
-            ArmoredOutputStream secretOutArmored;
-            if (armor)
-            {
-                secretOutArmored = new ArmoredOutputStream(secretOut);
-                if (!emitVersion)
-                {
-                    secretOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);
-                }
-                secretOut = secretOutArmored;
-            }
-            else
-            {
-                secretOutArmored = null;
-            }
-
-            PgpSecretKey secretKey = new PgpSecretKey(
-                PgpSignatureType,
-                PublicKeyAlgorithm,
-                publicKey,
-                privateKey,
-                DateTime.UtcNow,
-                identity,
-                SymmetricKeyAlgorithm,
-                passPhrase,
-                null,
-                null,
-                new SecureRandom()
-                //                ,"BC"
-                );
-
-                secretKey.Encode(secretOut);
-
-            secretOutArmored?.Dispose();
-
-            ArmoredOutputStream publicOutArmored;
-            if (armor)
-            {
-                publicOutArmored = new ArmoredOutputStream(publicOut);
-                if (!emitVersion)
-                {
-                    publicOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);
-                }
-                publicOut = publicOutArmored;
-            }
-            else
-            {
-                publicOutArmored = null;
-            }
-
-            PgpPublicKey key = secretKey.PublicKey;
-
-            key.Encode(publicOut);
-
-            publicOutArmored?.Dispose();
-        }
-
-        /*
-        * Search a secret key ring collection for a secret key corresponding to keyId if it exists.
-        */
-        private PgpPrivateKey FindSecretKey(PgpSecretKeyRingBundle pgpSec, long keyId, char[] pass)
-        {
-            PgpSecretKey pgpSecKey = pgpSec.GetSecretKey(keyId);
-
-            if (pgpSecKey == null)
-                return null;
-
-            return pgpSecKey.ExtractPrivateKey(pass);
-        }
-
-        private static int ReadInputLine(Stream encodedFile)
-        {
-            int lookAhead = -1;
-            int character;
-
-            while ((character = encodedFile.ReadByte()) >= 0)
-            {
-                if (character == '\r' || character == '\n')
-                {
-                    lookAhead = ReadPassedEol(character, encodedFile);
-                    break;
-                }
-            }
-
-            return lookAhead;
-        }
-
-        private static int ReadInputLine(MemoryStream streamOut, Stream encodedFile)
-        {
-            streamOut.SetLength(0);
-
-            int lookAhead = -1;
-            int character;
-
-            while ((character = encodedFile.ReadByte()) >= 0)
-            {
-                streamOut.WriteByte((byte)character);
-                if (character == '\r' || character == '\n')
-                {
-                    lookAhead = ReadPassedEol(streamOut, character, encodedFile);
-                    break;
-                }
-            }
-
-            return lookAhead;
-        }
-
-        private static int ReadInputLine(MemoryStream streamOut, int lookAhead, Stream encodedFile)
-        {
-            streamOut.SetLength(0);
-
-            int character = lookAhead;
-
-            do
-            {
-                streamOut.WriteByte((byte)character);
-                if (character == '\r' || character == '\n')
-                {
-                    lookAhead = ReadPassedEol(streamOut, character, encodedFile);
-                    break;
-                }
-            }
-            while ((character = encodedFile.ReadByte()) >= 0);
-
-            if (character < 0)
-            {
-                lookAhead = -1;
-            }
-
-            return lookAhead;
-        }
-
-        private static int ReadPassedEol(int lastCharacter, Stream encodedFile)
-        {
-            int lookAhead = encodedFile.ReadByte();
-
-            if (lastCharacter == '\r' && lookAhead == '\n')
-            {
-                lookAhead = encodedFile.ReadByte();
-            }
-
-            return lookAhead;
-        }
-
-        private static int ReadPassedEol(MemoryStream streamOut, int lastCharacter, Stream encodedFile)
-        {
-            int lookAhead = encodedFile.ReadByte();
-
-            if (lastCharacter == '\r' && lookAhead == '\n')
-            {
-                streamOut.WriteByte((byte)lookAhead);
-                lookAhead = encodedFile.ReadByte();
-            }
-
-            return lookAhead;
-        }
-
-        private static int GetLengthWithoutSeparatorOrTrailingWhitespace(byte[] line)
-        {
-            int end = line.Length - 1;
-
-            while (end >= 0 && IsWhiteSpace(line[end]))
-            {
-                end--;
-            }
-
-            return end + 1;
-        }
-
-        private static int GetLengthWithoutWhiteSpace(byte[] line)
-        {
-            int end = line.Length - 1;
-
-            while (end >= 0 && IsWhiteSpace(line[end]))
-            {
-                end--;
-            }
-
-            return end + 1;
-        }
-
-        private static bool IsWhiteSpace(byte b)
-        {
-            return IsLineEnding(b) || b == '\t' || b == ' ';
-        }
-
-        private static bool IsLineEnding(byte b)
-        {
-            return b == '\r' || b == '\n';
-        }
-
-        private static void ProcessLine(PgpSignature sig, byte[] line)
-        {
-            // note: trailing white space needs to be removed from the end of
-            // each line for signature calculation RFC 4880 Section 7.1
-            int length = GetLengthWithoutWhiteSpace(line);
-            if (length > 0)
-            {
-                sig.Update(line, 0, length);
-            }
-        }
-
-        private static byte[] LineSeparator
-        {
-            get { return Encoding.ASCII.GetBytes(Environment.NewLine); }
-        }
-
-        public void Dispose()
-        {
-        }
-
-        # endregion Misc Utilities
-        #endregion Private helpers
-    }
+	public enum PGPFileType
+	{
+		Binary,
+		Text,
+		UTF8
+	}
+
+	public class PGP : IPGPEncrypt, IPGPEncryptAsync, IPGPSign, IPGPSignAsync
+	{
+		public static PGP Instance => _instance ?? (_instance = new PGP());
+		private static PGP _instance;
+
+		private const int BufferSize = 0x10000;
+		private const string DefaultFileName = "name";
+
+		public CompressionAlgorithmTag CompressionAlgorithm { get; set; } = CompressionAlgorithmTag.Uncompressed;
+
+		public SymmetricKeyAlgorithmTag SymmetricKeyAlgorithm { get; set; } = SymmetricKeyAlgorithmTag.TripleDes;
+
+		public int PgpSignatureType { get; set; } = PgpSignature.DefaultCertification;
+
+		public PublicKeyAlgorithmTag PublicKeyAlgorithm { get; set; } = PublicKeyAlgorithmTag.RsaGeneral;
+
+		public PGPFileType FileType { get; set; } = PGPFileType.Binary;
+
+		public HashAlgorithmTag HashAlgorithmTag { get; set; } = HashAlgorithmTag.Sha1;
+
+		public IEncryptionKeys EncryptionKeys { get; private set; }
+
+		#region Constructor
+
+		public PGP()
+		{ }
+
+		public PGP(IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+		}
+
+		#endregion Constructor
+
+		#region Encrypt
+
+		#region EncryptFileAsync
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			string inputFilePath,
+			string outputFilePath,
+			string publicKeyFilePath,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="publicKeyFilePaths">PGP public key file paths</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			string inputFilePath,
+			string outputFilePath,
+			IEnumerable<string> publicKeyFilePaths,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList());
+			await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			string inputFilePath,
+			string outputFilePath,
+			IEncryptionKeys encryptionKeys,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptFileAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			string inputFilePath,
+			string outputFilePath,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
+			using (Stream outputStream = File.Create(outputFilePath))
+				await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			FileInfo publicKeyFile,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="publicKeyFiles">PGP public key files</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			IEnumerable<FileInfo> publicKeyFiles,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFiles);
+			await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			IEncryptionKeys encryptionKeys,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptFileAsync(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptFileAsync(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			using (FileStream inputStream = inputFile.OpenRead())
+			using (Stream outputStream = outputFile.OpenWrite())
+				await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		#endregion EncryptFileAsync
+
+		#region EncryptFile
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			string inputFilePath,
+			string outputFilePath,
+			string publicKeyFilePath,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			string inputFilePath,
+			string outputFilePath,
+			IEnumerable<string> publicKeyFilePaths,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList());
+			EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			string inputFilePath,
+			string outputFilePath,
+			IEncryptionKeys encryptionKeys,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptFile(inputFilePath, outputFilePath, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted</param>
+		/// <param name="outputFilePath">Output PGP encrypted file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			string inputFilePath,
+			string outputFilePath,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (FileStream inputStream = new FileStream(inputFilePath, FileMode.Open, FileAccess.Read))
+			using (Stream outputStream = File.Create(outputFilePath))
+				EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			FileInfo publicKeyFile,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="publicKeyFiles">PGP public key files</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			IEnumerable<FileInfo> publicKeyFiles,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFiles);
+			EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			IEncryptionKeys encryptionKeys,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptFile(inputFile, outputFile, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted</param>
+		/// <param name="outputFile">Output PGP encrypted file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptFile(
+			FileInfo inputFile,
+			FileInfo outputFile,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			using (FileStream inputStream = inputFile.OpenRead())
+			using (Stream outputStream = outputFile.OpenWrite())
+				EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		#endregion EncryptFile
+
+		#region EncryptStreamAsync
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAsync(
+			Stream inputStream,
+			Stream outputStream,
+			Stream publicKeyStream,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream,
+			IEnumerable<Stream> publicKeyStreams, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStreams);
+			await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptStreamAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAsync(Stream inputStream, Stream outputStream, bool armor = true,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				outputStream = new ArmoredOutputStream(outputStream);
+			}
+
+			PgpEncryptedDataGenerator pk =
+				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
+			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
+			{
+				pk.AddMethod(publicKey);
+			}
+
+			Stream @out = pk.Open(outputStream, new byte[1 << 16]);
+
+			if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
+			{
+				PgpCompressedDataGenerator comData = new PgpCompressedDataGenerator(CompressionAlgorithm);
+				await Utilities.WriteStreamToLiteralDataAsync(comData.Open(@out), FileTypeToChar(), inputStream, name);
+				comData.Close();
+			}
+			else
+				await Utilities.WriteStreamToLiteralDataAsync(@out, FileTypeToChar(), inputStream, name);
+
+			@out.Close();
+
+			if (armor)
+			{
+				outputStream.Close();
+			}
+		}
+
+		#endregion EncryptStreamAsync
+
+		#region EncryptStream
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStream(
+			Stream inputStream,
+			Stream outputStream,
+			Stream publicKeyStream,
+			bool armor = true,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStream(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams,
+			bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStreams);
+			EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptStream(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// PGP Encrypt the stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted</param>
+		/// <param name="outputStream">Output PGP encrypted stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStream(Stream inputStream, Stream outputStream, bool armor = true,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				outputStream = new ArmoredOutputStream(outputStream);
+			}
+
+			PgpEncryptedDataGenerator pk =
+				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
+
+			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
+			{
+				pk.AddMethod(publicKey);
+			}
+
+			Stream @out = pk.Open(outputStream, new byte[1 << 16]);
+
+			if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
+			{
+				PgpCompressedDataGenerator comData = new PgpCompressedDataGenerator(CompressionAlgorithm);
+				Utilities.WriteStreamToLiteralData(comData.Open(@out), FileTypeToChar(), inputStream, name);
+				comData.Close();
+			}
+			else
+				Utilities.WriteStreamToLiteralData(@out, FileTypeToChar(), inputStream, name);
+
+			@out.Close();
+
+			if (armor)
+			{
+				outputStream.Close();
+			}
+		}
+
+		#endregion EncryptStream
+
+		#region EncryptArmoredStringAsync
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAsync(
+			string input,
+			string publicKey,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="publicKeys">IEnumerable of PGP public keys</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAsync(string input, IEnumerable<string> publicKeys,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys =
+				new EncryptionKeys(await Task.WhenAll(publicKeys.Select(x => x.GetStreamAsync()).ToList()));
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAsync(string input, IEncryptionKeys encryptionKeys,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAsync(string input, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion EncryptArmoredStringAsync
+
+		#region EncryptArmoredString
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredString(
+			string input,
+			string publicKey,
+			bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="publicKeys">IEnumerable of PGP public keys</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredString(string input, IEnumerable<string> publicKeys, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeys.Select(x => x.GetStream()).ToList());
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredString(string input, IEncryptionKeys encryptionKeys, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP Encrypt the string.
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted</param>
+		/// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredString(string input, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStream(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion EncryptArmoredString
+
+		#endregion Encrypt
+
+		#region Encrypt and Sign
+
+		#region EncryptFileAndSignAsync
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, string publicKeyFilePath,
+			string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath),
+				passPhrase);
+			await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath,
+			IEnumerable<string> publicKeyFilePaths,
+			string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList(),
+				new FileInfo(privateKeyFilePath), passPhrase);
+			await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath,
+			IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptFileAndSignAsync(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(string inputFilePath, string outputFilePath, bool armor = true,
+			bool withIntegrityCheck = true)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						await OutputEncryptedAsync(inputFilePath, armoredOutputStream, withIntegrityCheck);
+					}
+				}
+				else
+					await OutputEncryptedAsync(inputFilePath, outputStream, withIntegrityCheck);
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
+			await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="publicKeyFiles">IEnumerable of PGP public key files</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile,
+			IEnumerable<FileInfo> publicKeyFiles,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFiles, privateKeyFile, passPhrase);
+			await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile,
+			IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptFileAndSignAsync(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public async Task EncryptFileAndSignAsync(FileInfo inputFile, FileInfo outputFile, bool armor = true,
+			bool withIntegrityCheck = true)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFilePath");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						await OutputEncryptedAsync(inputFile, armoredOutputStream, withIntegrityCheck);
+					}
+				}
+				else
+					await OutputEncryptedAsync(inputFile, outputStream, withIntegrityCheck);
+			}
+		}
+
+		#endregion EncryptFileAndSignAsync
+
+		#region EncryptFileAndSign
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(string inputFilePath, string outputFilePath, string publicKeyFilePath,
+			string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath),
+				passPhrase);
+			EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="publicKeyFilePaths">IEnumerable of PGP public key file paths</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(string inputFilePath, string outputFilePath,
+			IEnumerable<string> publicKeyFilePaths,
+			string privateKeyFilePath, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFilePaths.Select(x => new FileInfo(x)).ToList(),
+				new FileInfo(privateKeyFilePath), passPhrase);
+			EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
+			bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptFileAndSign(inputFilePath, outputFilePath, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFilePath">Output PGP encrypted and signed file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(string inputFilePath, string outputFilePath, bool armor = true,
+			bool withIntegrityCheck = true)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						OutputEncrypted(inputFilePath, armoredOutputStream, withIntegrityCheck);
+					}
+				}
+				else
+					OutputEncrypted(inputFilePath, outputStream, withIntegrityCheck);
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
+			EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="publicKeyFiles">IEnumerable of PGP public key files</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, IEnumerable<FileInfo> publicKeyFiles,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFiles, privateKeyFile, passPhrase);
+			EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys,
+			bool armor = true, bool withIntegrityCheck = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptFileAndSign(inputFile, outputFile, armor, withIntegrityCheck);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFile">Plain data file path to be encrypted and signed</param>
+		/// <param name="outputFile">Output PGP encrypted and signed file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		public void EncryptFileAndSign(FileInfo inputFile, FileInfo outputFile, bool armor = true,
+			bool withIntegrityCheck = true)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFilePath");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				if (armor)
+				{
+					using (var armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						OutputEncrypted(inputFile, armoredOutputStream, withIntegrityCheck);
+					}
+				}
+				else
+					OutputEncrypted(inputFile, outputStream, withIntegrityCheck);
+			}
+		}
+
+		#endregion EncryptFileAndSign
+
+		#region EncryptStreamAndSignAsync
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, Stream publicKeyStream,
+			Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+			await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream,
+			IEnumerable<Stream> publicKeyStreams,
+			Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStreams, privateKeyStream, passPhrase);
+			await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream,
+			IEncryptionKeys encryptionKeys, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			await EncryptStreamAndSignAsync(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task EncryptStreamAndSignAsync(Stream inputStream, Stream outputStream, bool armor = true,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				using (var armoredOutputStream = new ArmoredOutputStream(outputStream))
+				{
+					await OutputEncryptedAsync(inputStream, armoredOutputStream, withIntegrityCheck, name);
+				}
+			}
+			else
+				await OutputEncryptedAsync(inputStream, outputStream, withIntegrityCheck, name);
+		}
+
+		#endregion EncryptStreamAndSignAsync
+
+		#region EncryptStreamAndSign
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, Stream publicKeyStream,
+			Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+			EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="publicKeyStreams">IEnumerable of PGP public key streams</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, IEnumerable<Stream> publicKeyStreams,
+			Stream privateKeyStream, string passPhrase, bool armor = true, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStreams, privateKeyStream, passPhrase);
+			EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor = true, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			EncryptStreamAndSign(inputStream, outputStream, armor, withIntegrityCheck, name);
+		}
+
+		/// <summary>
+		/// Encrypt and sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be encrypted and signed</param>
+		/// <param name="outputStream">Output PGP encrypted and signed stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public void EncryptStreamAndSign(Stream inputStream, Stream outputStream, bool armor = true,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				using (var armoredOutputStream = new ArmoredOutputStream(outputStream))
+				{
+					OutputEncrypted(inputStream, armoredOutputStream, withIntegrityCheck, name);
+				}
+			}
+			else
+				OutputEncrypted(inputStream, outputStream, withIntegrityCheck, name);
+		}
+
+		#endregion EncryptStreamAndSign
+
+		#region EncryptArmoredStringAndSignAsync
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAndSignAsync(string input, string publicKey,
+			string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync(), await privateKey.GetStreamAsync(),
+				passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="publicKeys">IEnumerable of PGP public keys</param>
+		/// <param name="privateKey">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAndSignAsync(string input, List<string> publicKeys,
+			string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(await Task.WhenAll(publicKeys.Select(x => x.GetStreamAsync()).ToList()),
+				await privateKey.GetStreamAsync(), passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAndSignAsync(string input, IEncryptionKeys encryptionKeys,
+			bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public async Task<string> EncryptArmoredStringAndSignAsync(string input, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await EncryptStreamAndSignAsync(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion EncryptArmoredStringAndSignAsync
+
+		#region EncryptArmoredStringAndSign
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredStringAndSign(string input, string publicKey,
+			string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKey.GetStream(), privateKey.GetStream(), passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="publicKeys">IEnumerable of PGP public keys</param>
+		/// <param name="privateKey">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredStringAndSign(string input, List<string> publicKeys,
+			string privateKey, string passPhrase, bool withIntegrityCheck = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeys.Select(x => x.GetStream()).ToList(), privateKey.GetStream(),
+				passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Encrypt and sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be encrypted and signed</param>
+		/// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+		/// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
+		public string EncryptArmoredStringAndSign(string input, bool withIntegrityCheck = true,
+			string name = DefaultFileName)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				EncryptStreamAndSign(inputStream, outputStream, true, withIntegrityCheck, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion EncryptArmoredStringAndSign
+
+		#endregion Encrypt and Sign
+
+		#region Sign
+
+		#region SignFileAsync
+
+		// We do not implement signing with integrity check or name. (implemented for encryption)
+		public async Task SignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
+			bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			await SignFileAsync(inputFilePath, outputFilePath, encryptionKeys, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(string inputFilePath, string outputFilePath,
+			string privateKeyFilePath, string passPhrase, bool armor = true)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			await SignFileAsync(inputFilePath, outputFilePath, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
+			bool armor = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			await SignFileAsync(inputFilePath, outputFilePath, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(string inputFilePath, string outputFilePath,
+			bool armor = true)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						await OutputSignedAsync(inputFilePath, armoredOutputStream);
+					}
+				}
+				else
+					await OutputSignedAsync(inputFilePath, outputStream);
+			}
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			await SignFileAsync(inputFile, outputFile, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys,
+			bool armor = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			await SignFileAsync(inputFile, outputFile, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public async Task SignFileAsync(FileInfo inputFile, FileInfo outputFile,
+			bool armor = true)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			//if (name == DefaultFileName)
+//			{
+//				name = inputFile.Name;
+//			}
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						await OutputSignedAsync(inputFile, armoredOutputStream);
+					}
+				}
+				else
+					await OutputSignedAsync(inputFile, outputStream);
+			}
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(FileInfo inputFile, FileInfo outputFile,
+			FileInfo privateKeyFile, string passPhrase, bool armor = true)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			SignFile(inputFile, outputFile, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys,
+			bool armor = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			SignFile(inputFile, outputFile, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(FileInfo inputFile, FileInfo outputFile,
+			bool armor = true)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.FullName}] does not exist.");
+
+			//if (name == DefaultFileName)
+//			{
+//				name = inputFile.Name;
+//			}
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						OutputSigned(inputFile, armoredOutputStream);
+					}
+				}
+				else
+					OutputSigned(inputFile, outputStream);
+			}
+		}
+
+		#endregion SignFileAsync
+
+		#region SignFile
+		
+		// We do not implement signing with integrity check or name. (implemented for encryption)
+		public void SignFile(string inputFilePath, string outputFilePath, string privateKeyFilePath, string passPhrase,
+			bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			SignFile(inputFilePath, outputFilePath, privateKeyFilePath, passPhrase, armor);
+		}
+
+		public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys, bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			SignFile(inputFilePath, outputFilePath, encryptionKeys, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(string inputFilePath, string outputFilePath,
+			string privateKeyFilePath, string passPhrase, bool armor = true)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			SignFile(inputFilePath, outputFilePath, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys,
+			bool armor = true)
+		{
+			EncryptionKeys = encryptionKeys;
+			SignFile(inputFilePath, outputFilePath, armor);
+		}
+
+		/// <summary>
+		/// Sign the file pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		public void SignFile(string inputFilePath, string outputFilePath,
+			bool armor = true)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				if (armor)
+				{
+					using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+					{
+						OutputSigned(inputFilePath, armoredOutputStream);
+					}
+				}
+				else
+					OutputSigned(inputFilePath, outputStream);
+			}
+		}
+
+		#endregion SignFile
+
+		#region SignStreamAsync
+
+		// We do not implement signing with integrity check or name. (implemented for encryption)
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream, bool armor, bool withIntegrityCheck,
+			string name)
+		{
+			await SignStreamAsync(inputStream, outputStream, armor);
+		}
+
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			await SignStreamAsync(inputStream, outputStream, encryptionKeys, armor);
+		}
+
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream,
+			string passPhrase, bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			await SignStreamAsync(inputStream, outputStream, privateKeyStream, passPhrase, armor);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream,
+			Stream privateKeyStream, string passPhrase, bool armor = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			await SignStreamAsync(inputStream, outputStream, armor, name);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			await SignStreamAsync(inputStream, outputStream, armor, name);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task SignStreamAsync(Stream inputStream, Stream outputStream,
+			bool armor = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+				{
+					await OutputSignedAsync(inputStream, armoredOutputStream, name);
+				}
+			}
+			else
+				await OutputSignedAsync(inputStream, outputStream, name);
+		}
+
+		#endregion SignStreamAsync
+
+		#region SignStream
+		
+		// We do not implement signing with integrity check or name. (implemented for encryption)
+		public void SignStream(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase,
+			bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			SignStream(inputStream, outputStream, privateKeyStream, passPhrase, armor);
+		}
+
+		public void SignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys, bool armor,
+			bool withIntegrityCheck, string name)
+		{
+			SignStream(inputStream, outputStream, encryptionKeys, armor);
+		}
+
+		public void SignStream(Stream inputStream, Stream outputStream, bool armor, bool withIntegrityCheck,
+			string name)
+		{
+			SignStream(inputStream, outputStream, armor);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public void SignStream(Stream inputStream, Stream outputStream,
+			Stream privateKeyStream, string passPhrase, bool armor = true,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			SignStream(inputStream, outputStream, armor, name);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public void SignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys,
+			bool armor = true, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+			SignStream(inputStream, outputStream, armor, name);
+		}
+
+		/// <summary>
+		/// Sign the stream pointed to by unencryptedFileInfo and
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public void SignStream(Stream inputStream, Stream outputStream,
+			bool armor = true, string name = DefaultFileName)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			if (name == DefaultFileName && inputStream is FileStream fileStream)
+			{
+				string inputFilePath = fileStream.Name;
+				name = Path.GetFileName(inputFilePath);
+			}
+
+			if (armor)
+			{
+				using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+				{
+					OutputSigned(inputStream, armoredOutputStream, name);
+				}
+			}
+			else
+				OutputSigned(inputStream, outputStream, name);
+		}
+
+		#endregion SignStream
+
+		#region SignArmoredStringAsync
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task<string> SignArmoredStringAsync(string input, string privateKey, string passPhrase,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await SignStreamAsync(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task<string> SignArmoredStringAsync(string input, IEncryptionKeys encryptionKeys,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await SignStreamAsync(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public async Task<string> SignArmoredStringAsync(string input,
+			string name = DefaultFileName)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await SignStreamAsync(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion SignArmoredStringAsync
+
+		#region SignArmoredString
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public string SignArmoredString(string input, string privateKey, string passPhrase,
+			string name = DefaultFileName)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				SignStream(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public string SignArmoredString(string input, IEncryptionKeys encryptionKeys, string name = DefaultFileName)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				SignStream(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Sign the string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="name">Name of signed file in message, defaults to the input file name</param>
+		public string SignArmoredString(string input, string name = DefaultFileName)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				SignStream(inputStream, outputStream, true, name);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion SignArmoredString
+
+		#endregion Sign
+
+		#region ClearSign
+
+		#region ClearSignFileAsync
+
+		// https://github.com/bcgit/bc-csharp/blob/f18a2dbbc2c1b4277e24a2e51f09cac02eedf1f5/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath, string privateKeyFilePath,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			await ClearSignFileAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath,
+			IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await ClearSignFileAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		public async Task ClearSignFileAsync(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				await OutputClearSignedAsync(inputFilePath, outputStream);
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			await ClearSignFileAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await ClearSignFileAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		public async Task ClearSignFileAsync(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.Name}] does not exist.");
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				await OutputClearSignedAsync(inputFile, outputStream);
+			}
+		}
+
+		#endregion ClearSignFileAsync
+
+		#region ClearSignFile
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void ClearSignFile(string inputFilePath, string outputFilePath, string privateKeyFilePath,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			ClearSignFile(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void ClearSignFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			ClearSignFile(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be signed</param>
+		/// <param name="outputFilePath">Output PGP signed file path</param>
+		public void ClearSignFile(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Input file [{inputFilePath}] does not exist.");
+
+			using (Stream outputStream = File.Create(outputFilePath))
+			{
+				OutputClearSigned(inputFilePath, outputStream);
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void ClearSignFile(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			ClearSignFile(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void ClearSignFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			ClearSignFile(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// Clear sign the file pointed to by unencryptedFileInfo
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be signed</param>
+		/// <param name="outputFile">Output PGP signed file</param>
+		public void ClearSignFile(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Input file [{inputFile.Name}] does not exist.");
+
+			using (Stream outputStream = outputFile.OpenWrite())
+			{
+				OutputClearSigned(inputFile, outputStream);
+			}
+		}
+
+		#endregion ClearSignFile
+
+		#region ClearSignStreamAsync
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			await ClearSignStreamAsync(inputStream, outputStream);
+		}
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await ClearSignStreamAsync(inputStream, outputStream);
+		}
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		public async Task ClearSignStreamAsync(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			await OutputClearSignedAsync(inputStream, outputStream);
+		}
+
+		#endregion ClearSignStreamAsync
+
+		#region ClearSignStream
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void ClearSignStream(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			ClearSignStream(inputStream, outputStream);
+		}
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void ClearSignStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			ClearSignStream(inputStream, outputStream);
+		}
+
+		/// <summary>
+		/// Clear sign the provided stream
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be signed</param>
+		/// <param name="outputStream">Output PGP signed stream</param>
+		public void ClearSignStream(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			OutputClearSigned(inputStream, outputStream);
+		}
+
+		#endregion ClearSignStream
+
+		#region ClearSignArmoredStringAsync
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task<string> ClearSignArmoredStringAsync(string input, string privateKey, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await ClearSignStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<string> ClearSignArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await ClearSignStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		public async Task<string> ClearSignArmoredStringAsync(string input)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await ClearSignStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion ClearSignArmoredStringAsync
+
+		#region ClearSignArmoredString
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public string ClearSignArmoredString(string input, string privateKey, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				ClearSignStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public string ClearSignArmoredString(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				ClearSignStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// Clear sign the provided string
+		/// </summary>
+		/// <param name="input">Plain string to be signed</param>
+		public string ClearSignArmoredString(string input)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				ClearSignStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion ClearSignArmoredString
+
+		#endregion ClearSign
+
+		#region Decrypt
+
+		#region DecryptFileAsync
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task DecryptFileAsync(string inputFilePath, string outputFilePath, string privateKeyFilePath,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			await DecryptFileAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task DecryptFileAsync(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptFileAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		public async Task DecryptFileAsync(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+			using (Stream outStream = File.Create(outputFilePath))
+				await DecryptStreamAsync(inputStream, outStream);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			await DecryptFileAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptFileAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		public async Task DecryptFileAsync(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+			using (Stream outStream = outputFile.OpenWrite())
+				await DecryptStreamAsync(inputStream, outStream);
+		}
+
+		#endregion DecryptFileAsync
+
+		#region DecryptFile
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void DecryptFile(string inputFilePath, string outputFilePath, string privateKeyFilePath,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(privateKeyFilePath), passPhrase);
+			DecryptFile(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void DecryptFile(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptFile(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <param name="outputFilePath">Output PGP decrypted file path</param>
+		public void DecryptFile(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+			using (Stream outStream = File.Create(outputFilePath))
+				Decrypt(inputStream, outStream);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void DecryptFile(FileInfo inputFile, FileInfo outputFile, FileInfo privateKeyFile, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyFile, passPhrase);
+			DecryptFile(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void DecryptFile(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptFile(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file</param>
+		/// <param name="outputFile">Output PGP decrypted file</param>
+		public void DecryptFile(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+			using (Stream outStream = outputFile.OpenWrite())
+				DecryptStream(inputStream, outStream);
+		}
+
+		#endregion DecryptFile
+
+		#region DecryptStreamAsync
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream, Stream privateKeyStream,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			await DecryptStreamAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream,
+			IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptStreamAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		public async Task<Stream> DecryptStreamAsync(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			await DecryptAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		#endregion DecryptStreamAsync
+
+		#region DecryptStream
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public Stream DecryptStream(Stream inputStream, Stream outputStream, Stream privateKeyStream, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKeyStream, passPhrase);
+			DecryptStream(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public Stream DecryptStream(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptStream(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		public Stream DecryptStream(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			Decrypt(inputStream, outputStream);
+			return outputStream;
+		}
+
+		#endregion DecryptStream
+
+		#region DecryptArmoredStringAsync
+
+		/// <summary>
+		/// PGP decrypt a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted data stream</param>
+		/// <param name="privateKey">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task<string> DecryptArmoredStringAsync(string input, string privateKey, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(await privateKey.GetStreamAsync(), passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<string> DecryptArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string</param>
+		public async Task<string> DecryptArmoredStringAsync(string input)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion DecryptArmoredStringAsync
+
+		#region DecryptArmoredString
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="input">PGP encrypted data stream</param>
+		/// <param name="privateKey">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public string DecryptArmoredString(string input, string privateKey, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(privateKey.GetStream(), passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public string DecryptArmoredString(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string</param>
+		public string DecryptArmoredString(string input)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStream(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion DecryptArmoredString
+
+		#endregion Decrypt
+
+		#region DecryptAndVerify
+
+		#region DecryptFileAndVerifyAsync
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath,
+			string publicKeyFilePath, string privateKeyFilePath, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath),
+				passPhrase);
+			await DecryptFileAndVerifyAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath,
+			IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptFileAndVerifyAsync(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		public async Task DecryptFileAndVerifyAsync(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+			using (Stream outStream = File.Create(outputFilePath))
+				await DecryptStreamAndVerifyAsync(inputStream, outStream);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
+			FileInfo privateKeyFile, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
+			await DecryptFileAndVerifyAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile,
+			IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptFileAndVerifyAsync(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file path</param>
+		public async Task DecryptFileAndVerifyAsync(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+			using (Stream outStream = outputFile.OpenWrite())
+				await DecryptStreamAndVerifyAsync(inputStream, outStream);
+		}
+
+		#endregion DecryptFileAndVerifyAsync
+
+		#region DecryptFileAndVerify
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		/// <param name="privateKeyFilePath">PGP secret key file path</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void DecryptFileAndVerify(string inputFilePath, string outputFilePath, string publicKeyFilePath,
+			string privateKeyFilePath, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath), new FileInfo(privateKeyFilePath),
+				passPhrase);
+			DecryptFileAndVerify(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void DecryptFileAndVerify(string inputFilePath, string outputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptFileAndVerify(inputFilePath, outputFilePath);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFilePath">Output PGP decrypted and verified file path</param>
+		public void DecryptFileAndVerify(string inputFilePath, string outputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (string.IsNullOrEmpty(outputFilePath))
+				throw new ArgumentException("OutputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+			using (Stream outStream = File.Create(outputFilePath))
+				DecryptAndVerify(inputStream, outStream);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		/// <param name="privateKeyFile">PGP secret key file</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile, FileInfo publicKeyFile,
+			FileInfo privateKeyFile, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile, privateKeyFile, passPhrase);
+			DecryptFileAndVerify(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptFileAndVerify(inputFile, outputFile);
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given file.
+		/// </summary>
+		/// <param name="inputFile">PGP encrypted data file path to be decrypted and verified</param>
+		/// <param name="outputFile">Output PGP decrypted and verified file</param>
+		public void DecryptFileAndVerify(FileInfo inputFile, FileInfo outputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (outputFile == null)
+				throw new ArgumentException("OutputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+			using (Stream outStream = outputFile.OpenWrite())
+				DecryptStreamAndVerify(inputStream, outStream);
+		}
+
+		#endregion DecryptFileAndVerify
+
+		#region DecryptStreamAndVerifyAsync
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream,
+			Stream publicKeyStream, Stream privateKeyStream, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+			await DecryptStreamAndVerifyAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
+		public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream,
+			IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			await DecryptStreamAndVerifyAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		public async Task<Stream> DecryptStreamAndVerifyAsync(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			await DecryptAndVerifyAsync(inputStream, outputStream);
+			return outputStream;
+		}
+
+		#endregion DecryptStreamAndVerifyAsync
+
+		#region DecryptStreamAndVerify
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		/// <param name="privateKeyStream">PGP secret key stream</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream, Stream publicKeyStream,
+			Stream privateKeyStream, string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream, privateKeyStream, passPhrase);
+			DecryptStreamAndVerify(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			DecryptStreamAndVerify(inputStream, outputStream);
+			return outputStream;
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		public Stream DecryptStreamAndVerify(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			DecryptAndVerify(inputStream, outputStream);
+			return outputStream;
+		}
+
+		#endregion DecryptStreamAndVerify
+
+		#region DecryptArmoredStringAndVerifyAsync
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public async Task<string> DecryptArmoredStringAndVerifyAsync(string input, string publicKey, string privateKey,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync(), await privateKey.GetStreamAsync(),
+				passPhrase);
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAndVerifyAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
+		public async Task<string> DecryptArmoredStringAndVerifyAsync(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAndVerifyAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		public async Task<string> DecryptArmoredStringAndVerifyAsync(string input)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+			using (Stream outputStream = new MemoryStream())
+			{
+				await DecryptStreamAndVerifyAsync(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return await outputStream.GetStringAsync();
+			}
+		}
+
+		#endregion DecryptArmoredStringAndVerifyAsync
+
+		#region DecryptArmoredStringAndVerify
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		/// <param name="publicKey">PGP public key</param>
+		/// <param name="privateKey">PGP secret key</param>
+		/// <param name="passPhrase">PGP secret key password</param>
+		public string DecryptArmoredStringAndVerify(string input, string publicKey, string privateKey,
+			string passPhrase)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKey.GetStream(), privateKey.GetStream(), passPhrase);
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStreamAndVerify(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public key, private key and passphrase</param>
+		public string DecryptArmoredStringAndVerify(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStreamAndVerify(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		/// <summary>
+		/// PGP decrypt and verify a given string.
+		/// </summary>
+		/// <param name="input">PGP encrypted string to be decrypted and verified</param>
+		public string DecryptArmoredStringAndVerify(string input)
+		{
+			using (Stream inputStream = input.GetStream())
+			using (Stream outputStream = new MemoryStream())
+			{
+				DecryptStreamAndVerify(inputStream, outputStream);
+				outputStream.Seek(0, SeekOrigin.Begin);
+				return outputStream.GetString();
+			}
+		}
+
+		#endregion DecryptArmoredStringAndVerify
+
+		#region VerifyFileAsync
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		public async Task<bool> VerifyFileAsync(string inputFilePath, string publicKeyFilePath)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			return await VerifyFileAsync(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		public async Task<bool> VerifyFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyFileAsync(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		public async Task<bool> VerifyFileAsync(string inputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+				return await VerifyAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		public async Task<bool> VerifyFileAsync(FileInfo inputFile, FileInfo publicKeyFile)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			return await VerifyFileAsync(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		public async Task<bool> VerifyFileAsync(FileInfo inputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyFileAsync(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		public async Task<bool> VerifyFileAsync(FileInfo inputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+				return await VerifyAsync(inputStream);
+		}
+
+		#endregion VerifyFileAsync
+
+		#region VerifyFile
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		public bool VerifyFile(string inputFilePath, string publicKeyFilePath)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			return VerifyFile(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyFile(string inputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return VerifyFile(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		public bool VerifyFile(string inputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+				return Verify(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		public bool VerifyFile(FileInfo inputFile, FileInfo publicKeyFile)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			return VerifyFile(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="encryptionKeys">IEncryptionKeys object containing public keys</param>
+		public bool VerifyFile(FileInfo inputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return VerifyFile(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		public bool VerifyFile(FileInfo inputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentException("EncryptionKeys");
+
+			if (!inputFile.Exists)
+				throw new FileNotFoundException($"Encrypted File [{inputFile.FullName}] not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+				return Verify(inputStream);
+		}
+
+		#endregion VerifyFile
+
+		#region VerifyStreamAsync
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		public async Task<bool> VerifyStreamAsync(Stream inputStream, Stream publicKeyStream)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			return await VerifyStreamAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyStreamAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		public async Task<bool> VerifyStreamAsync(Stream inputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			return await VerifyAsync(inputStream);
+		}
+
+		#endregion VerifyStreamAsync
+
+		#region VerifyStream
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		public bool VerifyStream(Stream inputStream, Stream publicKeyStream)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			return Verify(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyStream(Stream inputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return Verify(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">Plain data stream to be verified</param>
+		public bool VerifyStream(Stream inputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			return Verify(inputStream);
+		}
+
+		#endregion VerifyStream
+
+		#region VerifyArmoredStringAsync
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		/// <param name="publicKey">PGP public key stream</param>
+		public async Task<bool> VerifyArmoredStringAsync(string input, string publicKey)
+		{
+			EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
+
+			using (Stream inputStream = await input.GetStreamAsync())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return await VerifyStreamAsync(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return await VerifyStreamAsync(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		public async Task<bool> VerifyArmoredStringAsync(string input)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return await VerifyStreamAsync(inputStream);
+			// }
+		}
+
+		#endregion VerifyArmoredStringAsync
+
+		#region VerifyArmoredString
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		/// <param name="publicKey">PGP public key</param>
+		public bool VerifyArmoredString(string input, string publicKey)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
+
+			using (Stream inputStream = input.GetStream())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return VerifyStream(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyArmoredString(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return VerifyStream(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given string.
+		/// </summary>
+		/// <param name="input">Plain string to be verified</param>
+		public bool VerifyArmoredString(string input)
+		{
+			using (Stream inputStream = input.GetStream())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return VerifyStream(inputStream);
+			// }
+		}
+
+		#endregion VerifyArmoredString
+
+		#region VerifyClearFileAsync
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		public async Task<bool> VerifyClearFileAsync(string inputFilePath, string publicKeyFilePath)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			return await VerifyClearFileAsync(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyClearFileAsync(string inputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyClearFileAsync(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		public async Task<bool> VerifyClearFileAsync(string inputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+				return await VerifyClearAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		public async Task<bool> VerifyClearFileAsync(FileInfo inputFile, FileInfo publicKeyFile)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			return await VerifyClearFileAsync(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyClearFileAsync(FileInfo inputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyClearFileAsync(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		public async Task<bool> VerifyClearFileAsync(FileInfo inputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+				return await VerifyClearAsync(inputStream);
+		}
+
+		#endregion VerifyClearFileAsync
+
+		#region VerifyClearFile
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="publicKeyFilePath">PGP public key file path</param>
+		public bool VerifyClearFile(string inputFilePath, string publicKeyFilePath)
+		{
+			EncryptionKeys = new EncryptionKeys(new FileInfo(publicKeyFilePath));
+			return VerifyClearFile(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyClearFile(string inputFilePath, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return VerifyClearFile(inputFilePath);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFilePath">Plain data file path to be verified</param>
+		public bool VerifyClearFile(string inputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Encryption Key not found.");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+				return VerifyClear(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="publicKeyFile">PGP public key file</param>
+		public bool VerifyClearFile(FileInfo inputFile, FileInfo publicKeyFile)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyFile);
+			return VerifyClearFile(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyClearFile(FileInfo inputFile, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return VerifyClearFile(inputFile);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed file.
+		/// </summary>
+		/// <param name="inputFile">Plain data file to be verified</param>
+		public bool VerifyClearFile(FileInfo inputFile)
+		{
+			if (inputFile == null)
+				throw new ArgumentException("InputFile");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+
+			using (Stream inputStream = inputFile.OpenRead())
+				return VerifyClear(inputStream);
+		}
+
+		#endregion VerifyClearFile
+
+		#region VerifyClearStreamAsync
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed data stream to be verified</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		public async Task<bool> VerifyClearStreamAsync(Stream inputStream, Stream publicKeyStream)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			return await VerifyClearStreamAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed data stream to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyClearStreamAsync(Stream inputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return await VerifyClearStreamAsync(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed data stream to be verified</param>
+		public async Task<bool> VerifyClearStreamAsync(Stream inputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			return await VerifyClearAsync(inputStream);
+		}
+
+		#endregion VerifyClearStreamAsync
+
+		#region VerifyClearStream
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed stream to be verified</param>
+		/// <param name="publicKeyStream">PGP public key stream</param>
+		public bool VerifyClearStream(Stream inputStream, Stream publicKeyStream)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKeyStream);
+			return VerifyClearStream(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed stream to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyClearStream(Stream inputStream, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+			return VerifyClearStream(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed stream.
+		/// </summary>
+		/// <param name="inputStream">Clear signed stream to be verified</param>
+		public bool VerifyClearStream(Stream inputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (EncryptionKeys == null)
+				throw new ArgumentNullException(nameof(EncryptionKeys), "Verification Key not found.");
+			if (inputStream.Position != 0)
+				throw new ArgumentException("inputStream should be at start of stream");
+
+			return VerifyClear(inputStream);
+		}
+
+		#endregion VerifyClearStream
+
+		#region VerifyClearArmoredStringAsync
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		/// <param name="publicKey">PGP public key</param>
+		public async Task<bool> VerifyClearArmoredStringAsync(string input, string publicKey)
+		{
+			EncryptionKeys = new EncryptionKeys(await publicKey.GetStreamAsync());
+
+			using (Stream inputStream = await input.GetStreamAsync())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return await VerifyClearStreamAsync(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public async Task<bool> VerifyClearArmoredStringAsync(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = await input.GetStreamAsync())
+				// using (Stream outputStream = new MemoryStream())
+				// {
+				return await VerifyClearStreamAsync(inputStream);
+			// }
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		public async Task<bool> VerifyClearArmoredStringAsync(string input)
+		{
+			using (Stream inputStream = await input.GetStreamAsync())
+				return await VerifyClearStreamAsync(inputStream);
+		}
+
+		#endregion VerifyClearArmoredStringAsync
+
+		#region VerifyClearArmoredString
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		/// <param name="publicKey">PGP public key</param>
+		public bool VerifyClearArmoredString(string input, string publicKey)
+		{
+			EncryptionKeys = new EncryptionKeys(publicKey.GetStream());
+
+			using (Stream inputStream = input.GetStream())
+				return VerifyClearStream(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		/// <param name="encryptionKeys">Encryption keys</param>
+		public bool VerifyClearArmoredString(string input, IEncryptionKeys encryptionKeys)
+		{
+			EncryptionKeys = encryptionKeys;
+
+			using (Stream inputStream = input.GetStream())
+				return VerifyClearStream(inputStream);
+		}
+
+		/// <summary>
+		/// PGP verify a given clear signed string.
+		/// </summary>
+		/// <param name="input">Clear signed string to be verified</param>
+		public bool VerifyClearArmoredString(string input)
+		{
+			using (Stream inputStream = input.GetStream())
+				return VerifyClearStream(inputStream);
+		}
+
+		#endregion VerifyClearArmoredString
+
+		#endregion DecryptAndVerify
+
+		#region GetRecipients
+
+		/// <summary>
+		/// PGP get a recipients keys id of an encrypted file.
+		/// </summary>
+		/// <param name="inputFilePath">PGP encrypted data file path</param>
+		/// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
+		public IEnumerable<long> GetFileRecipients(string inputFilePath)
+		{
+			if (string.IsNullOrEmpty(inputFilePath))
+				throw new ArgumentException("InputFilePath");
+
+			if (!File.Exists(inputFilePath))
+				throw new FileNotFoundException($"Encrypted File [{inputFilePath}] not found.");
+
+			using (Stream inputStream = File.OpenRead(inputFilePath))
+				return GetStreamRecipients(inputStream);
+		}
+
+		/// <summary>
+		/// PGP get a recipients keys id of an encrypted stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
+		public IEnumerable<long> GetStreamRecipients(Stream inputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+
+			PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
+
+			PgpObject obj = objFactory.NextPgpObject();
+
+			// the first object might be a PGP marker packet.
+			PgpEncryptedDataList enc;
+
+			if (obj is PgpEncryptedDataList list)
+				enc = list;
+			else
+				enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
+
+			// If enc is null at this point, we failed to detect the contents of the encrypted stream.
+			if (enc == null)
+				throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
+
+			// Return keys id
+			return enc.GetEncryptedDataObjects().OfType<PgpPublicKeyEncryptedData>().Select(k => k.KeyId);
+		}
+
+		/// <summary>
+		/// PGP get a recipients keys id of an encrypted file.
+		/// </summary>
+		/// <param name="input">PGP encrypted string</param>
+		/// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
+		public IEnumerable<long> GetArmoredStringRecipients(string input)
+		{
+			if (string.IsNullOrEmpty(input))
+				throw new ArgumentException("Input");
+
+			using (Stream inputStream = input.GetStream())
+				return GetStreamRecipients(inputStream);
+		}
+
+		#endregion GetRecipients
+
+		#region GenerateKey
+
+		public async Task GenerateKeyAsync(string publicKeyFilePath, string privateKeyFilePath, string username = null,
+			string password = null, int strength = 1024, int certainty = 8, bool emitVersion = true)
+		{
+			await Task.Run(() => GenerateKey(publicKeyFilePath, privateKeyFilePath, username, password, strength,
+				certainty, emitVersion));
+		}
+
+		public void GenerateKey(string publicKeyFilePath, string privateKeyFilePath, string username = null,
+			string password = null, int strength = 1024, int certainty = 8, bool emitVersion = true)
+		{
+			if (string.IsNullOrEmpty(publicKeyFilePath))
+				throw new ArgumentException("PublicKeyFilePath");
+			if (string.IsNullOrEmpty(privateKeyFilePath))
+				throw new ArgumentException("PrivateKeyFilePath");
+
+			using (Stream pubs = File.Open(publicKeyFilePath, FileMode.Create))
+			using (Stream pris = File.Open(privateKeyFilePath, FileMode.Create))
+				GenerateKey(pubs, pris, username, password, strength, certainty, emitVersion: emitVersion);
+		}
+
+		public void GenerateKey(Stream publicKeyStream, Stream privateKeyStream, string username = null,
+			string password = null, int strength = 1024, int certainty = 8, bool armor = true, bool emitVersion = true)
+		{
+			username = username ?? string.Empty;
+			password = password ?? string.Empty;
+
+			IAsymmetricCipherKeyPairGenerator kpg = new RsaKeyPairGenerator();
+			kpg.Init(new RsaKeyGenerationParameters(BigInteger.ValueOf(0x13), new SecureRandom(), strength, certainty));
+			AsymmetricCipherKeyPair kp = kpg.GenerateKeyPair();
+
+			ExportKeyPair(privateKeyStream, publicKeyStream, kp.Public, kp.Private, username, password.ToCharArray(),
+				armor, emitVersion);
+		}
+
+		#endregion GenerateKey
+
+		#region Private helpers
+
+		#region OutputEncryptedAsync
+
+		private async Task OutputEncryptedAsync(string inputFilePath, Stream outputStream, bool withIntegrityCheck)
+		{
+			await OutputEncryptedAsync(new FileInfo(inputFilePath), outputStream, withIntegrityCheck);
+		}
+
+		private async Task OutputEncryptedAsync(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck)
+		{
+			using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
+			{
+				using (Stream compressedOut = ChainCompressedOut(encryptedOut))
+				{
+					PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+					using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
+					{
+						using (FileStream inputFileStream = inputFile.OpenRead())
+						{
+							await WriteOutputAndSignAsync(compressedOut, literalOut, inputFileStream,
+								signatureGenerator);
+						}
+					}
+				}
+			}
+		}
+
+		private async Task OutputEncryptedAsync(Stream inputStream, Stream outputStream, bool withIntegrityCheck,
+			string name)
+		{
+			using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
+			{
+				using (Stream compressedOut = ChainCompressedOut(encryptedOut))
+				{
+					PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+					using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
+					{
+						await WriteOutputAndSignAsync(compressedOut, literalOut, inputStream, signatureGenerator);
+					}
+				}
+			}
+		}
+
+		#endregion OutputEncryptedAsync
+
+		#region OutputEncrypted
+
+		private void OutputEncrypted(string inputFilePath, Stream outputStream, bool withIntegrityCheck)
+		{
+			OutputEncrypted(new FileInfo(inputFilePath), outputStream, withIntegrityCheck);
+		}
+
+		private void OutputEncrypted(FileInfo inputFile, Stream outputStream, bool withIntegrityCheck)
+		{
+			using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
+			{
+				using (Stream compressedOut = ChainCompressedOut(encryptedOut))
+				{
+					PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+					using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
+					{
+						using (FileStream inputFileStream = inputFile.OpenRead())
+						{
+							WriteOutputAndSign(compressedOut, literalOut, inputFileStream, signatureGenerator);
+						}
+					}
+				}
+			}
+		}
+
+		private void OutputEncrypted(Stream inputStream, Stream outputStream, bool withIntegrityCheck, string name)
+		{
+			using (Stream encryptedOut = ChainEncryptedOut(outputStream, withIntegrityCheck))
+			{
+				using (Stream compressedOut = ChainCompressedOut(encryptedOut))
+				{
+					PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+					using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
+					{
+						WriteOutputAndSign(compressedOut, literalOut, inputStream, signatureGenerator);
+					}
+				}
+			}
+		}
+
+		#endregion OutputEncrypted
+
+		#region OutputSignedAsync
+
+		private async Task OutputSignedAsync(string inputFilePath, Stream outputStream)
+		{
+			await OutputSignedAsync(new FileInfo(inputFilePath), outputStream);
+		}
+
+		private async Task OutputSignedAsync(FileInfo inputFile, Stream outputStream)
+		{
+			using (Stream compressedOut = ChainCompressedOut(outputStream))
+			{
+				PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+				using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
+				{
+					using (FileStream inputFileStream = inputFile.OpenRead())
+					{
+						await WriteOutputAndSignAsync(compressedOut, literalOut, inputFileStream, signatureGenerator);
+					}
+				}
+			}
+		}
+
+		private async Task OutputSignedAsync(Stream inputStream, Stream outputStream,
+			string name)
+		{
+			using (Stream compressedOut = ChainCompressedOut(outputStream))
+			{
+				PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+				using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
+				{
+					await WriteOutputAndSignAsync(compressedOut, literalOut, inputStream, signatureGenerator);
+				}
+			}
+		}
+
+		#endregion OutputSignedAsync
+
+		#region OutputSigned
+
+		private void OutputSigned(string inputFilePath, Stream outputStream)
+		{
+			OutputSigned(new FileInfo(inputFilePath), outputStream);
+		}
+
+		private void OutputSigned(FileInfo inputFile, Stream outputStream)
+		{
+			using (Stream compressedOut = ChainCompressedOut(outputStream))
+			{
+				PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+				using (Stream literalOut = ChainLiteralOut(compressedOut, inputFile))
+				{
+					using (FileStream inputFileStream = inputFile.OpenRead())
+					{
+						WriteOutputAndSign(compressedOut, literalOut, inputFileStream, signatureGenerator);
+					}
+				}
+			}
+		}
+
+		private void OutputSigned(Stream inputStream, Stream outputStream, string name)
+		{
+			using (Stream compressedOut = ChainCompressedOut(outputStream))
+			{
+				PgpSignatureGenerator signatureGenerator = InitSignatureGenerator(compressedOut);
+				using (Stream literalOut = ChainLiteralStreamOut(compressedOut, inputStream, name))
+				{
+					WriteOutputAndSign(compressedOut, literalOut, inputStream, signatureGenerator);
+				}
+			}
+		}
+
+		#endregion OutputSigned
+
+		#region OutputClearSignedAsync
+
+		private async Task OutputClearSignedAsync(string inputFilePath, Stream outputStream)
+		{
+			await OutputClearSignedAsync(new FileInfo(inputFilePath), outputStream);
+		}
+
+		private async Task OutputClearSignedAsync(FileInfo inputFile, Stream outputStream)
+		{
+			using (FileStream inputFileStream = inputFile.OpenRead())
+			{
+				await OutputClearSignedAsync(inputFileStream, outputStream);
+			}
+		}
+
+		private async Task OutputClearSignedAsync(Stream inputStream, Stream outputStream)
+		{
+			using (StreamReader streamReader = new StreamReader(inputStream))
+			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+			{
+				PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
+
+				while (streamReader.Peek() >= 0)
+				{
+					string line = await streamReader.ReadLineAsync();
+					byte[] lineByteArray = Encoding.ASCII.GetBytes(line);
+					// Does the line end with whitespace?
+					// Trailing white space needs to be removed from the end of the document for a valid signature RFC 4880 Section 7.1
+					string cleanLine = line.TrimEnd();
+					byte[] cleanLineByteArray = Encoding.ASCII.GetBytes(cleanLine);
+
+					pgpSignatureGenerator.Update(cleanLineByteArray, 0, cleanLineByteArray.Length);
+					await armoredOutputStream.WriteAsync(lineByteArray, 0, lineByteArray.Length);
+
+					// Add a line break back to the stream
+					armoredOutputStream.Write((byte)'\r');
+					armoredOutputStream.Write((byte)'\n');
+
+					// Update signature with line breaks unless we're on the last line
+					if (streamReader.Peek() >= 0)
+					{
+						pgpSignatureGenerator.Update((byte)'\r');
+						pgpSignatureGenerator.Update((byte)'\n');
+					}
+				}
+
+				armoredOutputStream.EndClearText();
+
+				BcpgOutputStream bcpgOutputStream = new BcpgOutputStream(armoredOutputStream);
+				pgpSignatureGenerator.Generate().Encode(bcpgOutputStream);
+			}
+		}
+
+		#endregion OutputClearSignedAsync
+
+		#region OutputClearSigned
+
+		private void OutputClearSigned(string inputFilePath, Stream outputStream)
+		{
+			OutputClearSigned(new FileInfo(inputFilePath), outputStream);
+		}
+
+		private void OutputClearSigned(FileInfo inputFile, Stream outputStream)
+		{
+			using (FileStream inputFileStream = inputFile.OpenRead())
+			{
+				OutputClearSigned(inputFileStream, outputStream);
+			}
+		}
+
+		private void OutputClearSigned(Stream inputStream, Stream outputStream)
+		{
+			using (StreamReader streamReader = new StreamReader(inputStream))
+			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream))
+			{
+				PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
+
+				while (streamReader.Peek() >= 0)
+				{
+					string line = streamReader.ReadLine();
+					if (line == null) continue;
+					byte[] lineByteArray = Encoding.ASCII.GetBytes(line);
+					// Does the line end with whitespace?
+					// Trailing white space needs to be removed from the end of the document for a valid signature RFC 4880 Section 7.1
+					string cleanLine = line.TrimEnd();
+					byte[] cleanLineByteArray = Encoding.ASCII.GetBytes(cleanLine);
+
+					pgpSignatureGenerator.Update(cleanLineByteArray, 0, cleanLineByteArray.Length);
+					armoredOutputStream.Write(lineByteArray, 0, lineByteArray.Length);
+
+					// Add a line break back to the stream
+					armoredOutputStream.Write((byte)'\r');
+					armoredOutputStream.Write((byte)'\n');
+
+					// Update signature with line breaks unless we're on the last line
+					if (streamReader.Peek() >= 0)
+					{
+						pgpSignatureGenerator.Update((byte)'\r');
+						pgpSignatureGenerator.Update((byte)'\n');
+					}
+				}
+
+				armoredOutputStream.EndClearText();
+
+				BcpgOutputStream bcpgOutputStream = new BcpgOutputStream(armoredOutputStream);
+				pgpSignatureGenerator.Generate().Encode(bcpgOutputStream);
+			}
+		}
+
+		#endregion OutputClearSigned
+
+		#region DecryptAsync
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <returns></returns>
+		private async Task DecryptAsync(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+
+			PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
+
+			PgpObject obj = objFactory.NextPgpObject();
+
+			// the first object might be a PGP marker packet.
+			PgpEncryptedDataList enc = null;
+			PgpObject message = null;
+
+			if (obj is PgpEncryptedDataList dataList)
+				enc = dataList;
+			else if (obj is PgpCompressedData compressedData)
+				message = compressedData;
+			else
+				enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
+
+			// If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
+			if (enc == null && message == null)
+				throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
+
+			// decrypt
+			PgpPrivateKey privateKey = null;
+			PgpPublicKeyEncryptedData pbe = null;
+			if (enc != null)
+			{
+				foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in enc.GetEncryptedDataObjects())
+				{
+					privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+					if (privateKey != null)
+					{
+						pbe = publicKeyEncryptedData;
+						break;
+					}
+				}
+
+				if (privateKey == null)
+					throw new ArgumentException("Secret key for message not found.");
+
+				PgpObjectFactory plainFact;
+
+				using (Stream clear = pbe.GetDataStream(privateKey))
+				{
+					plainFact = new PgpObjectFactory(clear);
+				}
+
+				message = plainFact.NextPgpObject();
+
+				if (message is PgpOnePassSignatureList)
+				{
+					message = plainFact.NextPgpObject();
+				}
+			}
+
+			if (message is PgpCompressedData pgpCompressedData)
+			{
+				PgpObjectFactory objectFactory;
+
+				using (Stream compDataIn = pgpCompressedData.GetDataStream())
+				{
+					objectFactory = new PgpObjectFactory(compDataIn);
+					message = objectFactory.NextPgpObject();
+				}
+
+				if (message is PgpOnePassSignatureList)
+				{
+					message = objectFactory.NextPgpObject();
+					var literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					await Streams.PipeAllAsync(unc, outputStream);
+				}
+				else
+				{
+					PgpLiteralData literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					await Streams.PipeAllAsync(unc, outputStream);
+				}
+			}
+			else if (message is PgpLiteralData literalData)
+			{
+				Stream unc = literalData.GetInputStream();
+				await Streams.PipeAllAsync(unc, outputStream);
+
+				if (pbe.IsIntegrityProtected())
+				{
+					if (!pbe.Verify())
+					{
+						throw new PgpException("Message failed integrity check.");
+					}
+				}
+			}
+			else if (message is PgpOnePassSignatureList)
+				throw new PgpException("Encrypted message contains a signed message - not literal data.");
+			else
+				throw new PgpException("Message is not a simple encrypted file.");
+		}
+
+		#endregion DecryptAsync
+
+		#region Decrypt
+
+		/// <summary>
+		/// PGP decrypt a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream</param>
+		/// <param name="outputStream">Output PGP decrypted stream</param>
+		/// <returns></returns>
+		private void Decrypt(Stream inputStream, Stream outputStream)
+		{
+			if (inputStream == null)
+				throw new ArgumentException("InputStream");
+			if (outputStream == null)
+				throw new ArgumentException("OutputStream");
+
+			PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
+
+			PgpObject obj = objFactory.NextPgpObject();
+
+			// the first object might be a PGP marker packet.
+			PgpEncryptedDataList enc = null;
+			PgpObject message = null;
+
+			if (obj is PgpEncryptedDataList dataList)
+				enc = dataList;
+			else if (obj is PgpCompressedData compressedData)
+				message = compressedData;
+			else
+				enc = (PgpEncryptedDataList)objFactory.NextPgpObject();
+
+			// If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
+			if (enc == null && message == null)
+				throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
+
+			// decrypt
+			PgpPrivateKey privateKey = null;
+			PgpPublicKeyEncryptedData pbe = null;
+			if (enc != null)
+			{
+				foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in enc.GetEncryptedDataObjects())
+				{
+					privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+					if (privateKey != null)
+					{
+						pbe = publicKeyEncryptedData;
+						break;
+					}
+				}
+
+				if (privateKey == null)
+					throw new ArgumentException("Secret key for message not found.");
+
+				PgpObjectFactory plainFact;
+
+				using (Stream clear = pbe.GetDataStream(privateKey))
+				{
+					plainFact = new PgpObjectFactory(clear);
+				}
+
+				message = plainFact.NextPgpObject();
+
+				if (message is PgpOnePassSignatureList)
+				{
+					message = plainFact.NextPgpObject();
+				}
+			}
+
+			if (message is PgpCompressedData pgpCompressedData)
+			{
+				PgpObjectFactory objectFactory;
+
+				using (Stream compDataIn = pgpCompressedData.GetDataStream())
+				{
+					objectFactory = new PgpObjectFactory(compDataIn);
+					message = objectFactory.NextPgpObject();
+				}
+
+				if (message is PgpOnePassSignatureList)
+				{
+					message = objectFactory.NextPgpObject();
+					PgpLiteralData literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					Streams.PipeAll(unc, outputStream);
+				}
+				else
+				{
+					PgpLiteralData literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					Streams.PipeAll(unc, outputStream);
+				}
+			}
+			else if (message is PgpLiteralData literalData)
+			{
+				Stream unc = literalData.GetInputStream();
+				Streams.PipeAll(unc, outputStream);
+
+				if (pbe.IsIntegrityProtected())
+				{
+					if (!pbe.Verify())
+					{
+						throw new PgpException("Message failed integrity check.");
+					}
+				}
+			}
+			else if (message is PgpOnePassSignatureList)
+				throw new PgpException("Encrypted message contains a signed message - not literal data.");
+			else
+				throw new PgpException("Message is not a simple encrypted file.");
+		}
+
+		#endregion Decrypt
+
+		#region DecryptAndVerifyAsync
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		private async Task DecryptAndVerifyAsync(Stream inputStream, Stream outputStream)
+		{
+			PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
+
+			PgpObject obj = objFactory.NextPgpObject();
+
+			// the first object might be a PGP marker packet.
+			PgpEncryptedDataList encryptedDataList = null;
+			PgpObject message = null;
+
+			if (obj is PgpEncryptedDataList dataList)
+				encryptedDataList = dataList;
+			else if (obj is PgpCompressedData compressedData)
+				message = compressedData;
+			else
+				encryptedDataList = (PgpEncryptedDataList)objFactory.NextPgpObject();
+
+			// If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
+			if (encryptedDataList == null && message == null)
+				throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
+
+			// decrypt
+			PgpPrivateKey privateKey = null;
+			PgpPublicKeyEncryptedData pbe = null;
+			if (encryptedDataList != null)
+			{
+				foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in
+				         encryptedDataList.GetEncryptedDataObjects())
+				{
+					privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+					if (privateKey != null)
+					{
+						pbe = publicKeyEncryptedData;
+						break;
+					}
+				}
+
+				if (privateKey == null)
+					throw new ArgumentException("Secret key for message not found.");
+
+				PgpObjectFactory plainFact;
+
+				using (Stream clear = pbe.GetDataStream(privateKey))
+				{
+					plainFact = new PgpObjectFactory(clear);
+				}
+
+				message = plainFact.NextPgpObject();
+
+				if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
+				{
+					PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
+					var keyIdToVerify = pgpOnePassSignature.KeyId;
+
+					// var verified = EncryptionKeys.ValidationPublicKey.KeyId == pgpOnePassSignature.KeyId ||
+					//                EncryptionKeys.ValidationPublicKey.GetKeySignatures().Cast<PgpSignature>()
+					// 	               .Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+					var verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+						out PgpPublicKey _);
+					if (verified == false)
+						throw new PgpException("Failed to verify file.");
+
+					message = plainFact.NextPgpObject();
+				}
+				else if (!(message is PgpCompressedData))
+					throw new PgpException("File was not signed.");
+			}
+
+			if (message is PgpCompressedData cData)
+			{
+				PgpObjectFactory objectFactory;
+
+				using (Stream compDataIn = cData.GetDataStream())
+				{
+					objectFactory = new PgpObjectFactory(compDataIn);
+					message = objectFactory.NextPgpObject();
+				}
+
+				if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
+				{
+					PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
+					var keyIdToVerify = pgpOnePassSignature.KeyId;
+
+					// var verified = EncryptionKeys.ValidationKeys.First().KeyId == pgpOnePassSignature.KeyId || EncryptionKeys.ValidationKeys.First().GetKeySignatures().Cast<PgpSignature>().Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+					var verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+						out PgpPublicKey _);
+					if (verified == false)
+						throw new PgpException("Failed to verify file.");
+
+					message = objectFactory.NextPgpObject();
+					PgpLiteralData literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					await Streams.PipeAllAsync(unc, outputStream);
+				}
+				else
+				{
+					throw new PgpException("File was not signed.");
+				}
+			}
+			else if (message is PgpLiteralData literalData)
+			{
+				Stream unc = literalData.GetInputStream();
+				await Streams.PipeAllAsync(unc, outputStream);
+
+				if (pbe.IsIntegrityProtected())
+				{
+					if (!pbe.Verify())
+					{
+						throw new PgpException("Message failed integrity check.");
+					}
+				}
+			}
+			else
+				throw new PgpException("File was not signed.");
+		}
+
+		#endregion DecryptAndVerifyAsync
+
+		#region DecryptAndVerify
+
+		/// <summary>
+		/// PGP decrypt and verify a given stream.
+		/// </summary>
+		/// <param name="inputStream">PGP encrypted data stream to be decrypted and verified</param>
+		/// <param name="outputStream">Output PGP decrypted and verified stream</param>
+		private void DecryptAndVerify(Stream inputStream, Stream outputStream)
+		{
+			PgpObjectFactory objFactory = new PgpObjectFactory(PgpUtilities.GetDecoderStream(inputStream));
+
+			PgpObject obj = objFactory.NextPgpObject();
+
+			// the first object might be a PGP marker packet.
+			PgpEncryptedDataList encryptedDataList = null;
+			PgpObject message = null;
+
+			if (obj is PgpEncryptedDataList dataList)
+				encryptedDataList = dataList;
+			else if (obj is PgpCompressedData compressedData)
+				message = compressedData;
+			else
+				encryptedDataList = (PgpEncryptedDataList)objFactory.NextPgpObject();
+
+			// If enc and message are null at this point, we failed to detect the contents of the encrypted stream.
+			if (encryptedDataList == null && message == null)
+				throw new ArgumentException("Failed to detect encrypted content format.", nameof(inputStream));
+
+			// decrypt
+			PgpPrivateKey privateKey = null;
+			PgpPublicKeyEncryptedData pbe = null;
+			if (encryptedDataList != null)
+			{
+				foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in
+				         encryptedDataList.GetEncryptedDataObjects())
+				{
+					privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+					if (privateKey != null)
+					{
+						pbe = publicKeyEncryptedData;
+						break;
+					}
+				}
+
+				if (privateKey == null)
+					throw new ArgumentException("Secret key for message not found.");
+
+				PgpObjectFactory plainFact;
+
+				using (Stream clear = pbe.GetDataStream(privateKey))
+				{
+					plainFact = new PgpObjectFactory(clear);
+				}
+
+				message = plainFact.NextPgpObject();
+
+				if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
+				{
+					PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
+					var keyIdToVerify = pgpOnePassSignature.KeyId;
+
+					// var verified = EncryptionKeys.ValidationPublicKey.KeyId == pgpOnePassSignature.KeyId ||
+					//                EncryptionKeys.ValidationPublicKey.GetKeySignatures().Cast<PgpSignature>()
+					// 	               .Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+					var verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+						out PgpPublicKey _);
+					if (verified == false)
+						throw new PgpException("Failed to verify file.");
+
+					message = plainFact.NextPgpObject();
+				}
+				else if (!(message is PgpCompressedData))
+					throw new PgpException("File was not signed.");
+			}
+
+			if (message is PgpCompressedData cData)
+			{
+				PgpObjectFactory objectFactory;
+
+				using (Stream compDataIn = cData.GetDataStream())
+				{
+					objectFactory = new PgpObjectFactory(compDataIn);
+					message = objectFactory.NextPgpObject();
+				}
+
+				if (message is PgpOnePassSignatureList pgpOnePassSignatureList)
+				{
+					PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
+					var keyIdToVerify = pgpOnePassSignature.KeyId;
+					// var verified = EncryptionKeys.ValidationPublicKey.KeyId == pgpOnePassSignature.KeyId ||
+					//                EncryptionKeys.ValidationPublicKey.GetKeySignatures().Cast<PgpSignature>()
+					// 	               .Select(x => x.KeyId).Contains(pgpOnePassSignature.KeyId);
+					var verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+						out PgpPublicKey _);
+					if (verified == false)
+						throw new PgpException("Failed to verify file.");
+
+					message = objectFactory.NextPgpObject();
+					var literalData = (PgpLiteralData)message;
+					Stream unc = literalData.GetInputStream();
+					Streams.PipeAll(unc, outputStream);
+				}
+				else
+				{
+					throw new PgpException("File was not signed.");
+				}
+			}
+			else if (message is PgpLiteralData literalData)
+			{
+				Stream unc = literalData.GetInputStream();
+				Streams.PipeAll(unc, outputStream);
+
+				if (pbe.IsIntegrityProtected())
+				{
+					if (!pbe.Verify())
+					{
+						throw new PgpException("Message failed integrity check.");
+					}
+				}
+			}
+			else
+				throw new PgpException("File was not signed.");
+		}
+
+		#endregion DecryptAndVerify
+
+		#region VerifyAsync
+
+		private Task<bool> VerifyAsync(Stream inputStream)
+		{
+			bool verified = false;
+
+			Stream encodedFile = PgpUtilities.GetDecoderStream(inputStream);
+			PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
+			PgpObject pgpObject = factory.NextPgpObject();
+
+			if (pgpObject is PgpCompressedData)
+			{
+				PgpPublicKeyEncryptedData publicKeyEncryptedData = Utilities.ExtractPublicKeyEncryptedData(encodedFile);
+
+				// Verify against public key ID and that of any sub keys
+				var keyIdToVerify = publicKeyEncryptedData.KeyId;
+				verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+					out PgpPublicKey _);
+			}
+			else if (pgpObject is PgpEncryptedDataList dataList)
+			{
+				PgpPublicKeyEncryptedData publicKeyEncryptedData = Utilities.ExtractPublicKey(dataList);
+				var keyIdToVerify = publicKeyEncryptedData.KeyId;
+				// If we encounter an encrypted packet, verify with the encryption keys used instead
+				// TODO does this even make sense? maybe throw exception instead, or try to decrypt first
+				verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.EncryptKeys, out PgpPublicKey _);
+				
+			}
+			else if (pgpObject is PgpOnePassSignatureList onePassSignatureList)
+			{
+				PgpOnePassSignature pgpOnePassSignature = onePassSignatureList[0];
+				PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
+				Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
+
+
+				// Verify against public key ID and that of any sub keys
+				var keyIdToVerify = pgpOnePassSignature.KeyId;
+				if (Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+					    out PgpPublicKey validationKey))
+				{
+					pgpOnePassSignature.InitVerify(validationKey);
+
+					int ch;
+					while ((ch = pgpLiteralStream.ReadByte()) >= 0)
+					{
+						pgpOnePassSignature.Update((byte)ch);
+					}
+
+					try
+					{
+						PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
+
+						for (int i = 0; i < pgpSignatureList.Count; i++)
+						{
+							PgpSignature pgpSignature = pgpSignatureList[i];
+
+							if (pgpOnePassSignature.Verify(pgpSignature))
+							{
+								verified = true;
+								break;
+							}
+						}
+					}
+					catch
+					{
+						verified = false;
+					}
+				}
+			}
+			else if (pgpObject is PgpSignatureList signatureList)
+			{
+				PgpSignature pgpSignature = signatureList[0];
+				PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
+				Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
+
+				// Verify against public key ID and that of any sub keys
+				if (Utilities.FindPublicKey(pgpSignature.KeyId, EncryptionKeys.VerificationKeys,
+					    out PgpPublicKey publicKey))
+				{
+					foreach (PgpSignature _ in publicKey.GetSignatures())
+					{
+						if (!verified)
+						{
+							pgpSignature.InitVerify(publicKey);
+
+							int ch;
+							while ((ch = pgpLiteralStream.ReadByte()) >= 0)
+							{
+								pgpSignature.Update((byte)ch);
+							}
+
+							verified = pgpSignature.Verify();
+						}
+						else
+						{
+							break;
+						}
+					}
+				}
+			}
+			else
+				throw new PgpException("Message is not a encrypted and signed file or simple signed file.");
+
+			return Task.FromResult(verified);
+		}
+
+		#endregion VerifyAsync
+
+		#region Verify
+
+		private bool Verify(Stream inputStream)
+		{
+			bool verified = false;
+
+			ArmoredInputStream encodedFile = new ArmoredInputStream(inputStream);
+			PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
+			PgpObject pgpObject = factory.NextPgpObject();
+
+			if (pgpObject is PgpCompressedData compressedData)
+			{
+				PgpObjectFactory pgpCompressedFactory = new PgpObjectFactory(compressedData.GetDataStream());
+
+				PgpOnePassSignatureList pgpOnePassSignatureList =
+					(PgpOnePassSignatureList)pgpCompressedFactory.NextPgpObject();
+				PgpOnePassSignature pgpOnePassSignature = pgpOnePassSignatureList[0];
+				PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
+				Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
+
+				var keyIdToVerify = pgpOnePassSignature.KeyId;
+
+				// Verify against public key ID and that of any sub keys
+				if (!Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.VerificationKeys,
+					    out PgpPublicKey publicKey)) return false;
+				foreach (PgpSignature _ in publicKey.GetSignatures())
+				{
+					if (!verified)
+					{
+						pgpOnePassSignature.InitVerify(publicKey);
+
+						int ch;
+						while ((ch = pgpLiteralStream.ReadByte()) >= 0)
+						{
+							pgpOnePassSignature.Update((byte)ch);
+						}
+
+						try
+						{
+							PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
+
+							for (int i = 0; i < pgpSignatureList.Count; i++)
+							{
+								PgpSignature pgpSignature = pgpSignatureList[i];
+
+								if (pgpOnePassSignature.Verify(pgpSignature))
+								{
+									verified = true;
+									break;
+								}
+							}
+						}
+						catch
+						{
+							verified = false;
+							break;
+						}
+					}
+					else
+					{
+						break;
+					}
+				}
+			}
+			else if (pgpObject is PgpEncryptedDataList encryptedDataList)
+			{
+				PgpPublicKeyEncryptedData publicKeyEncryptedData = Utilities.ExtractPublicKey(encryptedDataList);
+				var keyIdToVerify = publicKeyEncryptedData.KeyId;
+
+				// Verify against public key ID and that of any sub keys
+
+				// If we encounter an encrypted packet, verify the encryption key used instead
+				// TODO does this even make sense? maybe throw exception instead, or try to decrypt first
+				if (Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.EncryptKeys, out PgpPublicKey _))
+				{
+					verified = true;
+				}
+			}
+			else if (pgpObject is PgpOnePassSignatureList onePassSignatureList)
+			{
+				PgpOnePassSignature pgpOnePassSignature = onePassSignatureList[0];
+				PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
+				Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
+
+				// Verify against public key ID and that of any sub keys
+				if (Utilities.FindPublicKey(pgpOnePassSignature.KeyId, EncryptionKeys.VerificationKeys,
+					    out PgpPublicKey publicKey))
+				{
+					pgpOnePassSignature.InitVerify(publicKey);
+
+					int ch;
+					while ((ch = pgpLiteralStream.ReadByte()) >= 0)
+					{
+						pgpOnePassSignature.Update((byte)ch);
+					}
+
+					try
+					{
+						PgpSignatureList pgpSignatureList = (PgpSignatureList)factory.NextPgpObject();
+
+						for (int i = 0; i < pgpSignatureList.Count; i++)
+						{
+							PgpSignature pgpSignature = pgpSignatureList[i];
+
+							if (pgpOnePassSignature.Verify(pgpSignature))
+							{
+								verified = true;
+								break;
+							}
+						}
+					}
+					catch
+					{
+						verified = false;
+					}
+				}
+			}
+			else if (pgpObject is PgpSignatureList signatureList)
+			{
+				PgpSignature pgpSignature = signatureList[0];
+				PgpLiteralData pgpLiteralData = (PgpLiteralData)factory.NextPgpObject();
+				Stream pgpLiteralStream = pgpLiteralData.GetInputStream();
+
+				// Verify against public key ID and that of any sub keys
+				if (Utilities.FindPublicKey(pgpSignature.KeyId, EncryptionKeys.VerificationKeys,
+					    out PgpPublicKey publicKey))
+				{
+					foreach (PgpSignature _ in publicKey.GetSignatures())
+					{
+						if (!verified)
+						{
+							pgpSignature.InitVerify(publicKey);
+
+							int ch;
+							while ((ch = pgpLiteralStream.ReadByte()) >= 0)
+							{
+								pgpSignature.Update((byte)ch);
+							}
+
+							verified = pgpSignature.Verify();
+						}
+						else
+						{
+							break;
+						}
+					}
+				}
+			}
+			else
+				throw new PgpException("Message is not a encrypted and signed file or simple signed file.");
+
+			return verified;
+		}
+
+		#endregion Verify
+
+		#region VerifyClearAsync
+
+		// https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
+		private async Task<bool> VerifyClearAsync(Stream inputStream)
+		{
+			bool verified;
+
+			using (MemoryStream outStream = new MemoryStream())
+			{
+				using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))
+				{
+					MemoryStream lineOut = new MemoryStream();
+					byte[] lineSep = LineSeparator;
+					int lookAhead = ReadInputLine(lineOut, armoredInputStream);
+
+					// Read past message to signature and store message in stream
+					if (lookAhead != -1 && armoredInputStream.IsClearText())
+					{
+						byte[] line = lineOut.ToArray();
+						await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+						await outStream.WriteAsync(lineSep, 0, lineSep.Length);
+
+						while (lookAhead != -1 && armoredInputStream.IsClearText())
+						{
+							lookAhead = ReadInputLine(lineOut, lookAhead, armoredInputStream);
+
+							line = lineOut.ToArray();
+							await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+							await outStream.WriteAsync(lineSep, 0, lineSep.Length);
+						}
+					}
+					else if (lookAhead != -1)
+					{
+						byte[] line = lineOut.ToArray();
+						await outStream.WriteAsync(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+						await outStream.WriteAsync(lineSep, 0, lineSep.Length);
+					}
+
+					// Get public key from correctly positioned stream and initialise for verification
+					PgpObjectFactory pgpObjectFactory = new PgpObjectFactory(armoredInputStream);
+					PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObjectFactory.NextPgpObject();
+					PgpSignature pgpSignature = pgpSignatureList[0];
+
+					pgpSignature.InitVerify(EncryptionKeys.VerificationKeys.First());
+
+					// Read through message again and calculate signature
+					outStream.Position = 0;
+					lookAhead = ReadInputLine(lineOut, outStream);
+
+					ProcessLine(pgpSignature, lineOut.ToArray());
+
+					while (lookAhead != -1)
+					{
+						lookAhead = ReadInputLine(lineOut, lookAhead, outStream);
+
+						pgpSignature.Update((byte)'\r');
+						pgpSignature.Update((byte)'\n');
+
+						ProcessLine(pgpSignature, lineOut.ToArray());
+					}
+
+					verified = pgpSignature.Verify();
+				}
+			}
+
+			return verified;
+		}
+
+		#endregion VerifyClearAsync
+
+		#region VerifyClear
+
+		// https://github.com/bcgit/bc-csharp/blob/master/crypto/test/src/openpgp/examples/ClearSignedFileProcessor.cs
+		private bool VerifyClear(Stream inputStream)
+		{
+			bool verified;
+
+			using (MemoryStream outStream = new MemoryStream())
+			{
+
+				using (ArmoredInputStream armoredInputStream = new ArmoredInputStream(inputStream))
+				{
+					MemoryStream lineOut = new MemoryStream();
+					byte[] lineSep = LineSeparator;
+					int lookAhead = ReadInputLine(lineOut, armoredInputStream);
+
+					// Read past message to signature and store message in stream
+					if (lookAhead != -1 && armoredInputStream.IsClearText())
+					{
+						byte[] line = lineOut.ToArray();
+						outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+						outStream.Write(lineSep, 0, lineSep.Length);
+
+						while (lookAhead != -1 && armoredInputStream.IsClearText())
+						{
+							lookAhead = ReadInputLine(lineOut, lookAhead, armoredInputStream);
+
+							line = lineOut.ToArray();
+							outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+							outStream.Write(lineSep, 0, lineSep.Length);
+						}
+					}
+					else if (lookAhead != -1)
+					{
+						byte[] line = lineOut.ToArray();
+						outStream.Write(line, 0, GetLengthWithoutSeparatorOrTrailingWhitespace(line));
+						outStream.Write(lineSep, 0, lineSep.Length);
+					}
+
+					// Get public key from correctly positioned stream and initialise for verification
+					PgpObjectFactory pgpObjectFactory = new PgpObjectFactory(armoredInputStream);
+					PgpSignatureList pgpSignatureList = (PgpSignatureList)pgpObjectFactory.NextPgpObject();
+					PgpSignature pgpSignature = pgpSignatureList[0];
+
+					pgpSignature.InitVerify(EncryptionKeys.VerificationKeys.First());
+
+					// Read through message again and calculate signature
+					outStream.Position = 0;
+					lookAhead = ReadInputLine(lineOut, outStream);
+
+					ProcessLine(pgpSignature, lineOut.ToArray());
+
+					while (lookAhead != -1)
+					{
+						lookAhead = ReadInputLine(lineOut, lookAhead, outStream);
+
+						pgpSignature.Update((byte)'\r');
+						pgpSignature.Update((byte)'\n');
+
+						ProcessLine(pgpSignature, lineOut.ToArray());
+					}
+
+					verified = pgpSignature.Verify();
+				}
+			}
+
+			return verified;
+		}
+
+		#endregion VerifyClear
+
+		#region WriteOutputAndSign
+
+		private async Task WriteOutputAndSignAsync(Stream compressedOut, Stream literalOut, FileStream inputFilePath,
+			PgpSignatureGenerator signatureGenerator)
+		{
+			int length;
+			byte[] buf = new byte[BufferSize];
+			while ((length = await inputFilePath.ReadAsync(buf, 0, buf.Length)) > 0)
+			{
+				await literalOut.WriteAsync(buf, 0, length);
+				signatureGenerator.Update(buf, 0, length);
+			}
+
+			signatureGenerator.Generate().Encode(compressedOut);
+		}
+
+		private void WriteOutputAndSign(Stream compressedOut, Stream literalOut, FileStream inputFilePath,
+			PgpSignatureGenerator signatureGenerator)
+		{
+			int length;
+			byte[] buf = new byte[BufferSize];
+			while ((length = inputFilePath.Read(buf, 0, buf.Length)) > 0)
+			{
+				literalOut.Write(buf, 0, length);
+				signatureGenerator.Update(buf, 0, length);
+			}
+
+			signatureGenerator.Generate().Encode(compressedOut);
+		}
+
+		private async Task WriteOutputAndSignAsync(Stream compressedOut, Stream literalOut, Stream inputStream,
+			PgpSignatureGenerator signatureGenerator)
+		{
+			int length;
+			byte[] buf = new byte[BufferSize];
+			while ((length = await inputStream.ReadAsync(buf, 0, buf.Length)) > 0)
+			{
+				await literalOut.WriteAsync(buf, 0, length);
+				signatureGenerator.Update(buf, 0, length);
+			}
+
+			signatureGenerator.Generate().Encode(compressedOut);
+		}
+
+		private void WriteOutputAndSign(Stream compressedOut, Stream literalOut, Stream inputStream,
+			PgpSignatureGenerator signatureGenerator)
+		{
+			int length;
+			byte[] buf = new byte[BufferSize];
+			while ((length = inputStream.Read(buf, 0, buf.Length)) > 0)
+			{
+				literalOut.Write(buf, 0, length);
+				signatureGenerator.Update(buf, 0, length);
+			}
+
+			signatureGenerator.Generate().Encode(compressedOut);
+		}
+
+		#endregion WriteOutputAndSign
+
+		#region ChainEncryptedOut
+
+		// private Stream ChainEncryptedOut(Stream outputStream, IEncryptionKeys encryptionKeys, bool withIntegrityCheck)
+		// {
+		// 	var encryptedDataGenerator =
+		// 		new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
+		//
+		// 	foreach (PgpPublicKey publicKey in encryptionKeys.EncryptKeys)
+		// 	{
+		// 		encryptedDataGenerator.AddMethod(publicKey);
+		// 	}
+		//
+		// 	return encryptedDataGenerator.Open(outputStream, new byte[BufferSize]);
+		// }
+
+		private Stream ChainEncryptedOut(Stream outputStream, bool withIntegrityCheck)
+		{
+			var encryptedDataGenerator =
+				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
+
+			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
+			{
+				encryptedDataGenerator.AddMethod(publicKey);
+			}
+
+			return encryptedDataGenerator.Open(outputStream, new byte[BufferSize]);
+		}
+
+		#endregion ChainEncryptedOut
+
+		#region ChainCompressedOut
+
+		private Stream ChainCompressedOut(Stream encryptedOut)
+		{
+			if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
+			{
+				PgpCompressedDataGenerator compressedDataGenerator =
+					new PgpCompressedDataGenerator(CompressionAlgorithmTag.Zip);
+				return compressedDataGenerator.Open(encryptedOut);
+			}
+
+			return encryptedOut;
+		}
+
+		#endregion ChainCompressedOut
+
+		#region ChainLiteralOut
+
+		private Stream ChainLiteralOut(Stream compressedOut, FileInfo file)
+		{
+			PgpLiteralDataGenerator pgpLiteralDataGenerator = new PgpLiteralDataGenerator();
+			return pgpLiteralDataGenerator.Open(compressedOut, FileTypeToChar(), file.Name, file.Length,
+				DateTime.UtcNow);
+		}
+
+		#endregion ChainLiteralOut
+
+		#region ChainLiteralStreamOut
+
+		private Stream ChainLiteralStreamOut(Stream compressedOut, Stream inputStream, string name)
+		{
+			PgpLiteralDataGenerator pgpLiteralDataGenerator = new PgpLiteralDataGenerator();
+			return pgpLiteralDataGenerator.Open(compressedOut, FileTypeToChar(), name, inputStream.Length,
+				DateTime.UtcNow);
+		}
+
+		#endregion ChainLiteralStreamOut
+
+		#region InitSignatureGenerator
+
+		private PgpSignatureGenerator InitSignatureGenerator(Stream compressedOut)
+		{
+			PublicKeyAlgorithmTag tag = EncryptionKeys.SigningSecretKey.PublicKey.Algorithm;
+			PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
+			pgpSignatureGenerator.InitSign(PgpSignature.BinaryDocument, EncryptionKeys.SigningPrivateKey);
+			foreach (string userId in EncryptionKeys.SigningSecretKey.PublicKey.GetUserIds())
+			{
+				PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
+				subPacketGenerator.SetSignerUserId(false, userId);
+				pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
+				// Just the first one!
+				break;
+			}
+
+			pgpSignatureGenerator.GenerateOnePassVersion(false).Encode(compressedOut);
+			return pgpSignatureGenerator;
+		}
+
+		#endregion InitSignatureGenerator
+
+		#region InitClearSignatureGenerator
+
+		private PgpSignatureGenerator InitClearSignatureGenerator(ArmoredOutputStream armoredOutputStream)
+		{
+			PublicKeyAlgorithmTag tag = EncryptionKeys.SigningSecretKey.PublicKey.Algorithm;
+			PgpSignatureGenerator pgpSignatureGenerator = new PgpSignatureGenerator(tag, HashAlgorithmTag);
+			pgpSignatureGenerator.InitSign(PgpSignature.CanonicalTextDocument, EncryptionKeys.SigningPrivateKey);
+			armoredOutputStream.BeginClearText(HashAlgorithmTag);
+			foreach (string userId in EncryptionKeys.SigningSecretKey.PublicKey.GetUserIds())
+			{
+				PgpSignatureSubpacketGenerator subPacketGenerator = new PgpSignatureSubpacketGenerator();
+				subPacketGenerator.SetSignerUserId(false, userId);
+				pgpSignatureGenerator.SetHashedSubpackets(subPacketGenerator.Generate());
+				// Just the first one!
+				break;
+			}
+
+			return pgpSignatureGenerator;
+		}
+
+		#endregion InitClearSignatureGenerator
+
+		#region Misc Utilities
+
+		private char FileTypeToChar()
+		{
+			if (FileType == PGPFileType.UTF8)
+				return PgpLiteralData.Utf8;
+			if (FileType == PGPFileType.Text)
+				return PgpLiteralData.Text;
+			return PgpLiteralData.Binary;
+		}
+
+		private void ExportKeyPair(
+			Stream secretOut,
+			Stream publicOut,
+			AsymmetricKeyParameter publicKey,
+			AsymmetricKeyParameter privateKey,
+			string identity,
+			char[] passPhrase,
+			bool armor, bool emitVersion)
+		{
+			if (secretOut == null)
+				throw new ArgumentException("secretOut");
+			if (publicOut == null)
+				throw new ArgumentException("publicOut");
+
+			ArmoredOutputStream secretOutArmored;
+			if (armor)
+			{
+				secretOutArmored = new ArmoredOutputStream(secretOut);
+				if (!emitVersion)
+				{
+					secretOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);
+				}
+
+				secretOut = secretOutArmored;
+			}
+			else
+			{
+				secretOutArmored = null;
+			}
+
+			PgpSecretKey secretKey = new PgpSecretKey(
+				PgpSignatureType,
+				PublicKeyAlgorithm,
+				publicKey,
+				privateKey,
+				DateTime.UtcNow,
+				identity,
+				SymmetricKeyAlgorithm,
+				passPhrase,
+				null,
+				null,
+				new SecureRandom()
+			);
+
+			secretKey.Encode(secretOut);
+
+			secretOutArmored?.Dispose();
+
+			ArmoredOutputStream publicOutArmored;
+			if (armor)
+			{
+				publicOutArmored = new ArmoredOutputStream(publicOut);
+				if (!emitVersion)
+				{
+					publicOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);
+				}
+
+				publicOut = publicOutArmored;
+			}
+			else
+			{
+				publicOutArmored = null;
+			}
+
+			PgpPublicKey key = secretKey.PublicKey;
+
+			key.Encode(publicOut);
+
+			publicOutArmored?.Dispose();
+		}
+
+		private static int ReadInputLine(MemoryStream streamOut, Stream encodedFile)
+		{
+			streamOut.SetLength(0);
+
+			int lookAhead = -1;
+			int character;
+
+			while ((character = encodedFile.ReadByte()) >= 0)
+			{
+				streamOut.WriteByte((byte)character);
+				if (character == '\r' || character == '\n')
+				{
+					lookAhead = ReadPassedEol(streamOut, character, encodedFile);
+					break;
+				}
+			}
+
+			return lookAhead;
+		}
+
+		private static int ReadInputLine(MemoryStream streamOut, int lookAhead, Stream encodedFile)
+		{
+			streamOut.SetLength(0);
+
+			int character = lookAhead;
+
+			do
+			{
+				streamOut.WriteByte((byte)character);
+				if (character == '\r' || character == '\n')
+				{
+					lookAhead = ReadPassedEol(streamOut, character, encodedFile);
+					break;
+				}
+			} while ((character = encodedFile.ReadByte()) >= 0);
+
+			if (character < 0)
+			{
+				lookAhead = -1;
+			}
+
+			return lookAhead;
+		}
+
+		private static int ReadPassedEol(MemoryStream streamOut, int lastCharacter, Stream encodedFile)
+		{
+			int lookAhead = encodedFile.ReadByte();
+
+			if (lastCharacter == '\r' && lookAhead == '\n')
+			{
+				streamOut.WriteByte((byte)lookAhead);
+				lookAhead = encodedFile.ReadByte();
+			}
+
+			return lookAhead;
+		}
+
+		private static int GetLengthWithoutSeparatorOrTrailingWhitespace(byte[] line)
+		{
+			int end = line.Length - 1;
+
+			while (end >= 0 && IsWhiteSpace(line[end]))
+			{
+				end--;
+			}
+
+			return end + 1;
+		}
+
+		private static int GetLengthWithoutWhiteSpace(byte[] line)
+		{
+			int end = line.Length - 1;
+
+			while (end >= 0 && IsWhiteSpace(line[end]))
+			{
+				end--;
+			}
+
+			return end + 1;
+		}
+
+		private static bool IsWhiteSpace(byte b)
+		{
+			return IsLineEnding(b) || b == '\t' || b == ' ';
+		}
+
+		private static bool IsLineEnding(byte b)
+		{
+			return b == '\r' || b == '\n';
+		}
+
+		private static void ProcessLine(PgpSignature sig, byte[] line)
+		{
+			// note: trailing white space needs to be removed from the end of
+			// each line for signature calculation RFC 4880 Section 7.1
+			int length = GetLengthWithoutWhiteSpace(line);
+			if (length > 0)
+			{
+				sig.Update(line, 0, length);
+			}
+		}
+
+		private static byte[] LineSeparator => Encoding.ASCII.GetBytes(Environment.NewLine);
+
+		public void Dispose()
+		{ }
+
+		# endregion Misc Utilities
+
+		#endregion Private helpers
+		
+	}
 }

--- a/PgpCore/Streams.cs
+++ b/PgpCore/Streams.cs
@@ -1,19 +1,12 @@
 ﻿using Org.BouncyCastle.Utilities.IO;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PgpCore
 {
-    public sealed class Streams
+    public static class Streams
     {
         private const int BufferSize = 512;
-
-        private Streams()
-        {
-        }
 
         public static void Drain(Stream inStr)
         {
@@ -87,7 +80,7 @@ namespace PgpCore
             int numRead;
             while ((numRead = inStr.Read(bs, 0, bs.Length)) > 0)
             {
-                if ((limit - total) < numRead)
+                if (limit - total < numRead)
                     throw new StreamOverflowException("Data Overflow");
                 total += numRead;
                 outStr.Write(bs, 0, numRead);
@@ -158,7 +151,7 @@ namespace PgpCore
             int numRead;
             while ((numRead = await inStr.ReadAsync(bs, 0, bs.Length)) > 0)
             {
-                if ((limit - total) < numRead)
+                if (limit - total < numRead)
                     throw new StreamOverflowException("Data Overflow");
                 total += numRead;
                 await outStr.WriteAsync(bs, 0, numRead);

--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -12,720 +12,907 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Org.BouncyCastle.Bcpg.Sig;
 
 namespace PgpCore
 {
-    /// <remarks>Basic utility class.</remarks>
-    public sealed class Utilities
-    {
-        private Utilities()
-        {
-        }
-
-        public static MPInteger[] DsaSigToMpi(
-            byte[] encoding)
-        {
-            DerInteger i1, i2;
-
-            try
-            {
-                Asn1Sequence s = (Asn1Sequence)Asn1Object.FromByteArray(encoding);
-
-                i1 = (DerInteger)s[0];
-                i2 = (DerInteger)s[1];
-            }
-            catch (IOException e)
-            {
-                throw new PgpException("exception encoding signature", e);
-            }
-
-            return new MPInteger[] { new MPInteger(i1.Value), new MPInteger(i2.Value) };
-        }
-
-        public static MPInteger[] RsaSigToMpi(
-            byte[] encoding)
-        {
-            return new MPInteger[] { new MPInteger(new BigInteger(1, encoding)) };
-        }
-
-        public static string GetDigestName(
-            HashAlgorithmTag hashAlgorithm)
-        {
-            switch (hashAlgorithm)
-            {
-                case HashAlgorithmTag.Sha1:
-                    return "SHA1";
-                case HashAlgorithmTag.MD2:
-                    return "MD2";
-                case HashAlgorithmTag.MD5:
-                    return "MD5";
-                case HashAlgorithmTag.RipeMD160:
-                    return "RIPEMD160";
-                case HashAlgorithmTag.Sha224:
-                    return "SHA224";
-                case HashAlgorithmTag.Sha256:
-                    return "SHA256";
-                case HashAlgorithmTag.Sha384:
-                    return "SHA384";
-                case HashAlgorithmTag.Sha512:
-                    return "SHA512";
-                default:
-                    throw new PgpException("unknown hash algorithm tag in GetDigestName: " + hashAlgorithm);
-            }
-        }
-
-        public static string GetSignatureName(
-            PublicKeyAlgorithmTag keyAlgorithm,
-            HashAlgorithmTag hashAlgorithm)
-        {
-            string encAlg;
-            switch (keyAlgorithm)
-            {
-                case PublicKeyAlgorithmTag.RsaGeneral:
-                case PublicKeyAlgorithmTag.RsaSign:
-                    encAlg = "RSA";
-                    break;
-                case PublicKeyAlgorithmTag.Dsa:
-                    encAlg = "DSA";
-                    break;
-                case PublicKeyAlgorithmTag.ECDH:
-                    encAlg = "ECDH";
-                    break;
-                case PublicKeyAlgorithmTag.ECDsa:
-                    encAlg = "ECDSA";
-                    break;
-                case PublicKeyAlgorithmTag.ElGamalEncrypt: // in some malformed cases.
-                case PublicKeyAlgorithmTag.ElGamalGeneral:
-                    encAlg = "ElGamal";
-                    break;
-                default:
-                    throw new PgpException("unknown algorithm tag in signature:" + keyAlgorithm);
-            }
-
-            return GetDigestName(hashAlgorithm) + "with" + encAlg;
-        }
-
-        public static string GetSymmetricCipherName(
-                SymmetricKeyAlgorithmTag algorithm)
-        {
-            switch (algorithm)
-            {
-                case SymmetricKeyAlgorithmTag.Null:
-                    return null;
-                case SymmetricKeyAlgorithmTag.TripleDes:
-                    return "DESEDE";
-                case SymmetricKeyAlgorithmTag.Idea:
-                    return "IDEA";
-                case SymmetricKeyAlgorithmTag.Cast5:
-                    return "CAST5";
-                case SymmetricKeyAlgorithmTag.Blowfish:
-                    return "Blowfish";
-                case SymmetricKeyAlgorithmTag.Safer:
-                    return "SAFER";
-                case SymmetricKeyAlgorithmTag.Des:
-                    return "DES";
-                case SymmetricKeyAlgorithmTag.Aes128:
-                    return "AES";
-                case SymmetricKeyAlgorithmTag.Aes192:
-                    return "AES";
-                case SymmetricKeyAlgorithmTag.Aes256:
-                    return "AES";
-                case SymmetricKeyAlgorithmTag.Twofish:
-                    return "Twofish";
-                case SymmetricKeyAlgorithmTag.Camellia128:
-                    return "Camellia";
-                case SymmetricKeyAlgorithmTag.Camellia192:
-                    return "Camellia";
-                case SymmetricKeyAlgorithmTag.Camellia256:
-                    return "Camellia";
-                default:
-                    throw new PgpException("unknown symmetric algorithm: " + algorithm);
-            }
-        }
-
-        public static int GetKeySize(SymmetricKeyAlgorithmTag algorithm)
-        {
-            int keySize;
-            switch (algorithm)
-            {
-                case SymmetricKeyAlgorithmTag.Des:
-                    keySize = 64;
-                    break;
-                case SymmetricKeyAlgorithmTag.Idea:
-                case SymmetricKeyAlgorithmTag.Cast5:
-                case SymmetricKeyAlgorithmTag.Blowfish:
-                case SymmetricKeyAlgorithmTag.Safer:
-                case SymmetricKeyAlgorithmTag.Aes128:
-                case SymmetricKeyAlgorithmTag.Camellia128:
-                    keySize = 128;
-                    break;
-                case SymmetricKeyAlgorithmTag.TripleDes:
-                case SymmetricKeyAlgorithmTag.Aes192:
-                case SymmetricKeyAlgorithmTag.Camellia192:
-                    keySize = 192;
-                    break;
-                case SymmetricKeyAlgorithmTag.Aes256:
-                case SymmetricKeyAlgorithmTag.Twofish:
-                case SymmetricKeyAlgorithmTag.Camellia256:
-                    keySize = 256;
-                    break;
-                default:
-                    throw new PgpException("unknown symmetric algorithm: " + algorithm);
-            }
-
-            return keySize;
-        }
-
-        public static KeyParameter MakeKey(
-            SymmetricKeyAlgorithmTag algorithm,
-            byte[] keyBytes)
-        {
-            string algName = GetSymmetricCipherName(algorithm);
-
-            return ParameterUtilities.CreateKeyParameter(algName, keyBytes);
-        }
-
-        public static KeyParameter MakeRandomKey(
-            SymmetricKeyAlgorithmTag algorithm,
-            SecureRandom random)
-        {
-            int keySize = GetKeySize(algorithm);
-            byte[] keyBytes = new byte[(keySize + 7) / 8];
-            random.NextBytes(keyBytes);
-            return MakeKey(algorithm, keyBytes);
-        }
-
-        public static KeyParameter MakeKeyFromPassPhrase(
-            SymmetricKeyAlgorithmTag algorithm,
-            S2k s2k,
-            char[] passPhrase)
-        {
-            int keySize = GetKeySize(algorithm);
-            byte[] pBytes = Strings.ToByteArray(new string(passPhrase));
-            byte[] keyBytes = new byte[(keySize + 7) / 8];
-
-            int generatedBytes = 0;
-            int loopCount = 0;
-
-            while (generatedBytes < keyBytes.Length)
-            {
-                IDigest digest;
-                if (s2k != null)
-                {
-                    string digestName = GetDigestName(s2k.HashAlgorithm);
-
-                    try
-                    {
-                        digest = DigestUtilities.GetDigest(digestName);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new PgpException("can't find S2k digest", e);
-                    }
-
-                    for (int i = 0; i != loopCount; i++)
-                    {
-                        digest.Update(0);
-                    }
-
-                    byte[] iv = s2k.GetIV();
-
-                    switch (s2k.Type)
-                    {
-                        case S2k.Simple:
-                            digest.BlockUpdate(pBytes, 0, pBytes.Length);
-                            break;
-                        case S2k.Salted:
-                            digest.BlockUpdate(iv, 0, iv.Length);
-                            digest.BlockUpdate(pBytes, 0, pBytes.Length);
-                            break;
-                        case S2k.SaltedAndIterated:
-                            long count = s2k.IterationCount;
-                            digest.BlockUpdate(iv, 0, iv.Length);
-                            digest.BlockUpdate(pBytes, 0, pBytes.Length);
-
-                            count -= iv.Length + pBytes.Length;
-
-                            while (count > 0)
-                            {
-                                if (count < iv.Length)
-                                {
-                                    digest.BlockUpdate(iv, 0, (int)count);
-                                    break;
-                                }
-                                else
-                                {
-                                    digest.BlockUpdate(iv, 0, iv.Length);
-                                    count -= iv.Length;
-                                }
-
-                                if (count < pBytes.Length)
-                                {
-                                    digest.BlockUpdate(pBytes, 0, (int)count);
-                                    count = 0;
-                                }
-                                else
-                                {
-                                    digest.BlockUpdate(pBytes, 0, pBytes.Length);
-                                    count -= pBytes.Length;
-                                }
-                            }
-                            break;
-                        default:
-                            throw new PgpException("unknown S2k type: " + s2k.Type);
-                    }
-                }
-                else
-                {
-                    try
-                    {
-                        digest = DigestUtilities.GetDigest("MD5");
-
-                        for (int i = 0; i != loopCount; i++)
-                        {
-                            digest.Update(0);
-                        }
-
-                        digest.BlockUpdate(pBytes, 0, pBytes.Length);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new PgpException("can't find MD5 digest", e);
-                    }
-                }
-
-                byte[] dig = DigestUtilities.DoFinal(digest);
-
-                if (dig.Length > (keyBytes.Length - generatedBytes))
-                {
-                    Array.Copy(dig, 0, keyBytes, generatedBytes, keyBytes.Length - generatedBytes);
-                }
-                else
-                {
-                    Array.Copy(dig, 0, keyBytes, generatedBytes, dig.Length);
-                }
-
-                generatedBytes += dig.Length;
-
-                loopCount++;
-            }
-
-            Array.Clear(pBytes, 0, pBytes.Length);
-
-            return MakeKey(algorithm, keyBytes);
-        }
-
-        /// <summary>Write out the passed in file as a literal data packet.</summary>
-        public static async Task WriteFileToLiteralDataAsync(
-            Stream output,
-            char fileType,
-            FileInfo file)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, file.Name, file.Length, file.LastWriteTime);
-            await PipeFileContentsAsync(file, pOut, 4096);
-            lData.Close();
-        }
-
-        /// <summary>Write out the passed in file as a literal data packet.</summary>
-        public static void WriteFileToLiteralData(
-            Stream output,
-            char fileType,
-            FileInfo file)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, file.Name, file.Length, file.LastWriteTime);
-            PipeFileContents(file, pOut, 4096);
-            lData.Close();
-        }
-
-        /// <summary>Write out the passed in file as a literal data packet in partial packet format.</summary>
-        public static async Task WriteFileToLiteralDataAsync(
-            Stream output,
-            char fileType,
-            FileInfo file,
-            byte[] buffer)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, file.Name, file.LastWriteTime, buffer);
-            await PipeFileContentsAsync(file, pOut, buffer.Length);
-            lData.Close();
-        }
-
-        /// <summary>Write out the passed in file as a literal data packet in partial packet format.</summary>
-        public static void WriteFileToLiteralData(
-            Stream output,
-            char fileType,
-            FileInfo file,
-            byte[] buffer)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, file.Name, file.LastWriteTime, buffer);
-            PipeFileContents(file, pOut, buffer.Length);
-            lData.Close();
-        }
-
-        public static async Task WriteStreamToLiteralDataAsync(
-            Stream output,
-            char fileType,
-            Stream input,
-            string name)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, name, input.Length, DateTime.Now);
-            await PipeStreamContentsAsync(input, pOut, 4096);
-            lData.Close();
-        }
-
-        public static void WriteStreamToLiteralData(
-            Stream output,
-            char fileType,
-            Stream input,
-            string name)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, name, input.Length, DateTime.Now);
-            PipeStreamContents(input, pOut, 4096);
-            lData.Close();
-        }
-
-        public static async Task WriteStreamToLiteralDataAsync(
-            Stream output,
-            char fileType,
-            Stream input,
-            byte[] buffer,
-            string name)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, name, DateTime.Now, buffer);
-            await PipeStreamContentsAsync(input, pOut, buffer.Length);
-            lData.Close();
-        }
-
-        public static void WriteStreamToLiteralData(
-            Stream output,
-            char fileType,
-            Stream input,
-            byte[] buffer,
-            string name)
-        {
-            PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
-            Stream pOut = lData.Open(output, fileType, name, DateTime.Now, buffer);
-            PipeStreamContents(input, pOut, buffer.Length);
-            lData.Close();
-        }
-
-        /// <summary>
-        /// Opens a key ring file and returns first available sub-key suitable for encryption.
-        /// If such sub-key is not found, return master key that can encrypt.
-        /// </summary>
-        /// <param name="inputStream">Input stream containing the public key contents</param>
-        /// <returns></returns>
-        public static PgpPublicKey ReadPublicKey(Stream publicKeyStream)
-        {
-            using (Stream inputStream = PgpUtilities.GetDecoderStream(publicKeyStream))
-            {
-                PgpPublicKeyRingBundle pgpPub = new PgpPublicKeyRingBundle(inputStream);
-
-                // we just loop through the collection till we find a key suitable for encryption, in the real
-                // world you would probably want to be a bit smarter about this.
-                // iterate through the key rings.
-                foreach (PgpPublicKeyRing kRing in pgpPub.GetKeyRings())
-                {
-                    List<PgpPublicKey> keys = kRing.GetPublicKeys()
-                        .Cast<PgpPublicKey>()
-                        .Where(k => k.IsEncryptionKey).ToList();
-
-                    const int encryptKeyFlags = PgpKeyFlags.CanEncryptCommunications | PgpKeyFlags.CanEncryptStorage;
-
-                    foreach (PgpPublicKey key in keys.Where(k => k.Version >= 4))
-                    {
-                        foreach (PgpSignature s in key.GetSignatures())
-                        {
-                            if (s.HasSubpackets && s.GetHashedSubPackets().GetKeyFlags() == encryptKeyFlags)
-                                return key;
-                        }
-                    }
-
-                    if (keys.Any())
-                        return keys.First();
-                }
-            }
-
-            throw new ArgumentException("Can't find encryption key in key ring.");
-        }
-
-        /// <summary>
-        /// Parses a public key
-        /// </summary>
-        /// <param name="publicKey">The plain text value of the public key</param>
-        /// <returns></returns>
-        public static PgpPublicKey ReadPublicKey(string publicKey)
-        {
-
-            if (string.IsNullOrEmpty(publicKey))
-                throw new FileNotFoundException(String.Format("Public key was not provided"));
-
-            return ReadPublicKey(publicKey.GetStream());
-        }
-
-        /// <summary>
-        /// Parses a public key
-        /// </summary>
-        /// <param name="publicKeyFile">The path to the public key file</param>
-        /// <returns></returns>
-        public static PgpPublicKey ReadPublicKey(FileInfo publicKeyFile)
-        {
-            if (!publicKeyFile.Exists)
-                throw new FileNotFoundException(String.Format("File {0} was not found", publicKeyFile));
-            using (FileStream fs = publicKeyFile.OpenRead())
-                return ReadPublicKey(fs);
-        }
-
-        private static async Task PipeFileContentsAsync(FileInfo file, Stream pOut, int bufSize)
-        {
-            using (FileStream inputStream = file.OpenRead())
-            {
-                byte[] buf = new byte[bufSize];
-
-                int len;
-                while ((len = await inputStream.ReadAsync(buf, 0, buf.Length)) > 0)
-                {
-                    await pOut.WriteAsync(buf, 0, len);
-                }
-            }
-        }
-
-        private static void PipeFileContents(FileInfo file, Stream pOut, int bufSize)
-        {
-            using (FileStream inputStream = file.OpenRead())
-            {
-                byte[] buf = new byte[bufSize];
-
-                int len;
-                while ((len = inputStream.Read(buf, 0, buf.Length)) > 0)
-                {
-                    pOut.Write(buf, 0, len);
-                }
-            }
-        }
-
-        private static async Task PipeStreamContentsAsync(Stream input, Stream pOut, int bufSize)
-        {
-            byte[] buf = new byte[bufSize];
-
-            int len;
-            while ((len = await input.ReadAsync(buf, 0, buf.Length)) > 0)
-            {
-                await pOut.WriteAsync(buf, 0, len);
-            }
-        }
-
-        private static void PipeStreamContents(Stream input, Stream pOut, int bufSize)
-        {
-            byte[] buf = new byte[bufSize];
-
-            int len;
-            while ((len = input.Read(buf, 0, buf.Length)) > 0)
-            {
-                pOut.Write(buf, 0, len);
-            }
-        }
-
-        private const int ReadAhead = 60;
-
-        private static bool IsPossiblyBase64(
-            int ch)
-        {
-            return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
-                    || (ch >= '0' && ch <= '9') || (ch == '+') || (ch == '/')
-                    || (ch == '\r') || (ch == '\n');
-        }
-
-        /// <summary>
-        /// Return either an ArmoredInputStream or a BcpgInputStream based on whether
-        /// the initial characters of the stream are binary PGP encodings or not.
-        /// </summary>
-        public static Stream GetDecoderStream(
-            Stream inputStream)
-        {
-            // TODO Remove this restriction?
-            if (!inputStream.CanSeek)
-                throw new ArgumentException("inputStream must be seek-able", "inputStream");
-
-            long markedPos = inputStream.Position;
-
-            int ch = inputStream.ReadByte();
-            if ((ch & 0x80) != 0)
-            {
-                inputStream.Position = markedPos;
-
-                return inputStream;
-            }
-            else
-            {
-                if (!IsPossiblyBase64(ch))
-                {
-                    inputStream.Position = markedPos;
-
-                    return new ArmoredInputStream(inputStream);
-                }
-
-                byte[] buf = new byte[ReadAhead];
-                int count = 1;
-                int index = 1;
-
-                buf[0] = (byte)ch;
-                while (count != ReadAhead && (ch = inputStream.ReadByte()) >= 0)
-                {
-                    if (!IsPossiblyBase64(ch))
-                    {
-                        inputStream.Position = markedPos;
-
-                        return new ArmoredInputStream(inputStream);
-                    }
-
-                    if (ch != '\n' && ch != '\r')
-                    {
-                        buf[index++] = (byte)ch;
-                    }
-
-                    count++;
-                }
-
-                inputStream.Position = markedPos;
-
-                //
-                // nothing but new lines, little else, assume regular armoring
-                //
-                if (count < 4)
-                {
-                    return new ArmoredInputStream(inputStream);
-                }
-
-                //
-                // test our non-blank data
-                //
-                byte[] firstBlock = new byte[8];
-                Array.Copy(buf, 0, firstBlock, 0, firstBlock.Length);
-                byte[] decoded = Base64.Decode(firstBlock);
-
-                //
-                // it's a base64 PGP block.
-                //
-                bool hasHeaders = (decoded[0] & 0x80) == 0;
-
-                return new ArmoredInputStream(inputStream, hasHeaders);
-            }
-        }
-
-        public static PgpPublicKeyEncryptedData ExtractPublicKeyEncryptedData(System.IO.Stream encodedFile)
-        {
-            PgpEncryptedDataList encryptedDataList = GetEncryptedDataList(encodedFile);
-            PgpPublicKeyEncryptedData publicKeyED = ExtractPublicKey(encryptedDataList);
-            return publicKeyED;
-        }
-
-        public static PgpPublicKeyEncryptedData ExtractPublicKeyEncryptedData(PgpEncryptedDataList encryptedDataList)
-        {
-            PgpPublicKeyEncryptedData publicKeyED = ExtractPublicKey(encryptedDataList);
-            return publicKeyED;
-        }
-
-        public static PgpObject ProcessCompressedMessage(PgpObject message)
-        {
-            PgpCompressedData compressedData = (PgpCompressedData)message;
-            Stream compressedDataStream = compressedData.GetDataStream();
-            PgpObjectFactory compressedFactory = new PgpObjectFactory(compressedDataStream);
-            message = CheckForOnePassSignatureList(message, compressedFactory);
-            return message;
-        }
-
-        public static PgpObject CheckForOnePassSignatureList(PgpObject message, PgpObjectFactory compressedFactory)
-        {
-            message = compressedFactory.NextPgpObject();
-            if (message is PgpOnePassSignatureList)
-            {
-                message = compressedFactory.NextPgpObject();
-            }
-            return message;
-        }
-
-        public static PgpObject SkipSignatureList(PgpObjectFactory compressedFactory)
-        {
-            var message = compressedFactory.NextPgpObject();
-            while (message is PgpOnePassSignatureList || message is PgpSignatureList)
-            {
-                message = compressedFactory.NextPgpObject();
-            }
-            return message;
-        }
-
-        internal static PgpObject GetClearCompressedMessage(PgpPublicKeyEncryptedData publicKeyED, EncryptionKeys encryptionKeys)
-        {
-            PgpObjectFactory clearFactory = GetClearDataStream(encryptionKeys.PrivateKey, publicKeyED);
-            PgpObject message = clearFactory.NextPgpObject();
-            if (message is PgpOnePassSignatureList)
-                message = clearFactory.NextPgpObject();
-            return message;
-        }
-
-        public static PgpObjectFactory GetClearDataStream(PgpPrivateKey privateKey, PgpPublicKeyEncryptedData publicKeyED)
-        {
-            Stream clearStream = publicKeyED.GetDataStream(privateKey);
-            PgpObjectFactory clearFactory = new PgpObjectFactory(clearStream);
-            return clearFactory;
-        }
-
-        public static PgpPublicKeyEncryptedData ExtractPublicKey(PgpEncryptedDataList encryptedDataList)
-        {
-            PgpPublicKeyEncryptedData publicKeyED = null;
-            foreach (PgpPublicKeyEncryptedData privateKeyED in encryptedDataList.GetEncryptedDataObjects())
-            {
-                if (privateKeyED != null)
-                {
-                    publicKeyED = privateKeyED;
-                    break;
-                }
-            }
-            return publicKeyED;
-        }
-
-        public static PgpEncryptedDataList GetEncryptedDataList(Stream encodedFile)
-        {
-            PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
-            PgpObject pgpObject = factory.NextPgpObject();
-
-            PgpEncryptedDataList encryptedDataList;
-
-            if (pgpObject is PgpEncryptedDataList)
-            {
-                encryptedDataList = (PgpEncryptedDataList)pgpObject;
-            }
-            else
-            {
-                encryptedDataList = (PgpEncryptedDataList)factory.NextPgpObject();
-            }
-            return encryptedDataList;
-        }
-
-        public static PgpOnePassSignatureList GetPgpOnePassSignatureList(Stream encodedFile)
-        {
-            PgpObjectFactory factory = new PgpObjectFactory(encodedFile);
-            PgpObject pgpObject = factory.NextPgpObject();
-
-            PgpOnePassSignatureList pgpOnePassSignatureList;
-
-            if (pgpObject is PgpOnePassSignatureList)
-            {
-                pgpOnePassSignatureList = (PgpOnePassSignatureList)pgpObject;
-            }
-            else
-            {
-                pgpOnePassSignatureList = (PgpOnePassSignatureList)factory.NextPgpObject();
-            }
-
-            return pgpOnePassSignatureList;
-        }
-    }
+	/// <remarks>Basic utility class.</remarks>
+	public static class Utilities
+	{
+		public static MPInteger[] DsaSigToMpi(
+			byte[] encoding)
+		{
+			DerInteger i1, i2;
+
+			try
+			{
+				Asn1Sequence s = (Asn1Sequence)Asn1Object.FromByteArray(encoding);
+
+				i1 = (DerInteger)s[0];
+				i2 = (DerInteger)s[1];
+			}
+			catch (IOException e)
+			{
+				throw new PgpException("exception encoding signature", e);
+			}
+
+			return new[] { new MPInteger(i1.Value), new MPInteger(i2.Value) };
+		}
+
+		public static MPInteger[] RsaSigToMpi(
+			byte[] encoding)
+		{
+			return new[] { new MPInteger(new BigInteger(1, encoding)) };
+		}
+
+		public static string GetDigestName(
+			HashAlgorithmTag hashAlgorithm)
+		{
+			switch (hashAlgorithm)
+			{
+				case HashAlgorithmTag.Sha1:
+					return "SHA1";
+				case HashAlgorithmTag.MD2:
+					return "MD2";
+				case HashAlgorithmTag.MD5:
+					return "MD5";
+				case HashAlgorithmTag.RipeMD160:
+					return "RIPEMD160";
+				case HashAlgorithmTag.Sha224:
+					return "SHA224";
+				case HashAlgorithmTag.Sha256:
+					return "SHA256";
+				case HashAlgorithmTag.Sha384:
+					return "SHA384";
+				case HashAlgorithmTag.Sha512:
+					return "SHA512";
+				default:
+					throw new PgpException("unknown hash algorithm tag in GetDigestName: " + hashAlgorithm);
+			}
+		}
+
+		public static string GetSignatureName(
+			PublicKeyAlgorithmTag keyAlgorithm,
+			HashAlgorithmTag hashAlgorithm)
+		{
+			string encAlg;
+			switch (keyAlgorithm)
+			{
+				case PublicKeyAlgorithmTag.RsaGeneral:
+				case PublicKeyAlgorithmTag.RsaSign:
+					encAlg = "RSA";
+					break;
+				case PublicKeyAlgorithmTag.Dsa:
+					encAlg = "DSA";
+					break;
+				case PublicKeyAlgorithmTag.ECDH:
+					encAlg = "ECDH";
+					break;
+				case PublicKeyAlgorithmTag.ECDsa:
+					encAlg = "ECDSA";
+					break;
+				case PublicKeyAlgorithmTag.ElGamalEncrypt: // in some malformed cases.
+				case PublicKeyAlgorithmTag.ElGamalGeneral:
+					encAlg = "ElGamal";
+					break;
+				default:
+					throw new PgpException("unknown algorithm tag in signature:" + keyAlgorithm);
+			}
+
+			return GetDigestName(hashAlgorithm) + "with" + encAlg;
+		}
+
+		public static string GetSymmetricCipherName(
+			SymmetricKeyAlgorithmTag algorithm)
+		{
+			switch (algorithm)
+			{
+				case SymmetricKeyAlgorithmTag.Null:
+					return null;
+				case SymmetricKeyAlgorithmTag.TripleDes:
+					return "DESEDE";
+				case SymmetricKeyAlgorithmTag.Idea:
+					return "IDEA";
+				case SymmetricKeyAlgorithmTag.Cast5:
+					return "CAST5";
+				case SymmetricKeyAlgorithmTag.Blowfish:
+					return "Blowfish";
+				case SymmetricKeyAlgorithmTag.Safer:
+					return "SAFER";
+				case SymmetricKeyAlgorithmTag.Des:
+					return "DES";
+				case SymmetricKeyAlgorithmTag.Aes128:
+					return "AES";
+				case SymmetricKeyAlgorithmTag.Aes192:
+					return "AES";
+				case SymmetricKeyAlgorithmTag.Aes256:
+					return "AES";
+				case SymmetricKeyAlgorithmTag.Twofish:
+					return "Twofish";
+				case SymmetricKeyAlgorithmTag.Camellia128:
+					return "Camellia";
+				case SymmetricKeyAlgorithmTag.Camellia192:
+					return "Camellia";
+				case SymmetricKeyAlgorithmTag.Camellia256:
+					return "Camellia";
+				default:
+					throw new PgpException("unknown symmetric algorithm: " + algorithm);
+			}
+		}
+
+		public static int GetKeySize(SymmetricKeyAlgorithmTag algorithm)
+		{
+			int keySize;
+			switch (algorithm)
+			{
+				case SymmetricKeyAlgorithmTag.Des:
+					keySize = 64;
+					break;
+				case SymmetricKeyAlgorithmTag.Idea:
+				case SymmetricKeyAlgorithmTag.Cast5:
+				case SymmetricKeyAlgorithmTag.Blowfish:
+				case SymmetricKeyAlgorithmTag.Safer:
+				case SymmetricKeyAlgorithmTag.Aes128:
+				case SymmetricKeyAlgorithmTag.Camellia128:
+					keySize = 128;
+					break;
+				case SymmetricKeyAlgorithmTag.TripleDes:
+				case SymmetricKeyAlgorithmTag.Aes192:
+				case SymmetricKeyAlgorithmTag.Camellia192:
+					keySize = 192;
+					break;
+				case SymmetricKeyAlgorithmTag.Aes256:
+				case SymmetricKeyAlgorithmTag.Twofish:
+				case SymmetricKeyAlgorithmTag.Camellia256:
+					keySize = 256;
+					break;
+				default:
+					throw new PgpException("unknown symmetric algorithm: " + algorithm);
+			}
+
+			return keySize;
+		}
+
+		public static KeyParameter MakeKey(
+			SymmetricKeyAlgorithmTag algorithm,
+			byte[] keyBytes)
+		{
+			string algName = GetSymmetricCipherName(algorithm);
+
+			return ParameterUtilities.CreateKeyParameter(algName, keyBytes);
+		}
+
+		public static KeyParameter MakeRandomKey(
+			SymmetricKeyAlgorithmTag algorithm,
+			SecureRandom random)
+		{
+			int keySize = GetKeySize(algorithm);
+			byte[] keyBytes = new byte[(keySize + 7) / 8];
+			random.NextBytes(keyBytes);
+			return MakeKey(algorithm, keyBytes);
+		}
+
+		public static KeyParameter MakeKeyFromPassPhrase(
+			SymmetricKeyAlgorithmTag algorithm,
+			S2k s2K,
+			char[] passPhrase)
+		{
+			int keySize = GetKeySize(algorithm);
+			byte[] pBytes = Strings.ToByteArray(new string(passPhrase));
+			byte[] keyBytes = new byte[(keySize + 7) / 8];
+
+			int generatedBytes = 0;
+			int loopCount = 0;
+
+			while (generatedBytes < keyBytes.Length)
+			{
+				IDigest digest;
+				if (s2K != null)
+				{
+					string digestName = GetDigestName(s2K.HashAlgorithm);
+
+					try
+					{
+						digest = DigestUtilities.GetDigest(digestName);
+					}
+					catch (Exception e)
+					{
+						throw new PgpException("can't find S2k digest", e);
+					}
+
+					for (int i = 0; i != loopCount; i++)
+					{
+						digest.Update(0);
+					}
+
+					byte[] iv = s2K.GetIV();
+
+					switch (s2K.Type)
+					{
+						case S2k.Simple:
+							digest.BlockUpdate(pBytes, 0, pBytes.Length);
+							break;
+						case S2k.Salted:
+							digest.BlockUpdate(iv, 0, iv.Length);
+							digest.BlockUpdate(pBytes, 0, pBytes.Length);
+							break;
+						case S2k.SaltedAndIterated:
+							long count = s2K.IterationCount;
+							digest.BlockUpdate(iv, 0, iv.Length);
+							digest.BlockUpdate(pBytes, 0, pBytes.Length);
+
+							count -= iv.Length + pBytes.Length;
+
+							while (count > 0)
+							{
+								if (count < iv.Length)
+								{
+									digest.BlockUpdate(iv, 0, (int)count);
+									break;
+								}
+
+								digest.BlockUpdate(iv, 0, iv.Length);
+								count -= iv.Length;
+
+								if (count < pBytes.Length)
+								{
+									digest.BlockUpdate(pBytes, 0, (int)count);
+									count = 0;
+								}
+								else
+								{
+									digest.BlockUpdate(pBytes, 0, pBytes.Length);
+									count -= pBytes.Length;
+								}
+							}
+
+							break;
+						default:
+							throw new PgpException("unknown S2k type: " + s2K.Type);
+					}
+				}
+				else
+				{
+					try
+					{
+						digest = DigestUtilities.GetDigest("MD5");
+
+						for (int i = 0; i != loopCount; i++)
+						{
+							digest.Update(0);
+						}
+
+						digest.BlockUpdate(pBytes, 0, pBytes.Length);
+					}
+					catch (Exception e)
+					{
+						throw new PgpException("can't find MD5 digest", e);
+					}
+				}
+
+				byte[] dig = DigestUtilities.DoFinal(digest);
+
+				if (dig.Length > keyBytes.Length - generatedBytes)
+				{
+					Array.Copy(dig, 0, keyBytes, generatedBytes, keyBytes.Length - generatedBytes);
+				}
+				else
+				{
+					Array.Copy(dig, 0, keyBytes, generatedBytes, dig.Length);
+				}
+
+				generatedBytes += dig.Length;
+
+				loopCount++;
+			}
+
+			Array.Clear(pBytes, 0, pBytes.Length);
+
+			return MakeKey(algorithm, keyBytes);
+		}
+
+		/// <summary>Write out the passed in file as a literal data packet.</summary>
+		public static async Task WriteFileToLiteralDataAsync(
+			Stream output,
+			char fileType,
+			FileInfo file)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, file.Name, file.Length, file.LastWriteTime);
+			await PipeFileContentsAsync(file, pOut, 4096);
+			lData.Close();
+		}
+
+		/// <summary>Write out the passed in file as a literal data packet.</summary>
+		public static void WriteFileToLiteralData(
+			Stream output,
+			char fileType,
+			FileInfo file)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, file.Name, file.Length, file.LastWriteTime);
+			PipeFileContents(file, pOut, 4096);
+			lData.Close();
+		}
+
+		/// <summary>Write out the passed in file as a literal data packet in partial packet format.</summary>
+		public static async Task WriteFileToLiteralDataAsync(
+			Stream output,
+			char fileType,
+			FileInfo file,
+			byte[] buffer)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, file.Name, file.LastWriteTime, buffer);
+			await PipeFileContentsAsync(file, pOut, buffer.Length);
+			lData.Close();
+		}
+
+		/// <summary>Write out the passed in file as a literal data packet in partial packet format.</summary>
+		public static void WriteFileToLiteralData(
+			Stream output,
+			char fileType,
+			FileInfo file,
+			byte[] buffer)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, file.Name, file.LastWriteTime, buffer);
+			PipeFileContents(file, pOut, buffer.Length);
+			lData.Close();
+		}
+
+		public static async Task WriteStreamToLiteralDataAsync(
+			Stream output,
+			char fileType,
+			Stream input,
+			string name)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, name, input.Length, DateTime.Now);
+			await PipeStreamContentsAsync(input, pOut, 4096);
+			lData.Close();
+		}
+
+		public static void WriteStreamToLiteralData(
+			Stream output,
+			char fileType,
+			Stream input,
+			string name)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, name, input.Length, DateTime.Now);
+			PipeStreamContents(input, pOut, 4096);
+			lData.Close();
+		}
+
+		public static async Task WriteStreamToLiteralDataAsync(
+			Stream output,
+			char fileType,
+			Stream input,
+			byte[] buffer,
+			string name)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, name, DateTime.Now, buffer);
+			await PipeStreamContentsAsync(input, pOut, buffer.Length);
+			lData.Close();
+		}
+
+		public static void WriteStreamToLiteralData(
+			Stream output,
+			char fileType,
+			Stream input,
+			byte[] buffer,
+			string name)
+		{
+			PgpLiteralDataGenerator lData = new PgpLiteralDataGenerator();
+			Stream pOut = lData.Open(output, fileType, name, DateTime.Now, buffer);
+			PipeStreamContents(input, pOut, buffer.Length);
+			lData.Close();
+		}
+
+		/// <summary>
+		/// Opens a key ring file and returns first available sub-key suitable for encryption.
+		/// If such sub-key is not found, return master key that can encrypt.
+		/// </summary>
+		/// <param name="publicKeyStream">Input stream containing the public key contents</param>
+		/// <returns></returns>
+		public static PgpPublicKey ReadPublicKey(Stream publicKeyStream)
+		{
+			using (Stream inputStream = PgpUtilities.GetDecoderStream(publicKeyStream))
+			{
+				PgpPublicKeyRingBundle pgpPub = new PgpPublicKeyRingBundle(inputStream);
+
+				// we just loop through the collection till we find a key suitable for encryption, in the real
+				// world you would probably want to be a bit smarter about this.
+				// iterate through the key rings.
+				foreach (PgpPublicKeyRing kRing in pgpPub.GetKeyRings())
+				{
+					List<PgpPublicKey> keys = kRing.GetPublicKeys()
+						.Cast<PgpPublicKey>()
+						.Where(k => k.IsEncryptionKey).ToList();
+
+					const int encryptKeyFlags = PgpKeyFlags.CanEncryptCommunications | PgpKeyFlags.CanEncryptStorage;
+
+					foreach (PgpPublicKey key in keys.Where(k => k.Version >= 4))
+					{
+						foreach (PgpSignature s in key.GetSignatures())
+						{
+							if (s.HasSubpackets && s.GetHashedSubPackets().GetKeyFlags() == encryptKeyFlags)
+								return key;
+						}
+					}
+
+					if (keys.Any())
+						return keys.First();
+				}
+			}
+
+			throw new ArgumentException("Can't find encryption key in key ring.");
+		}
+
+		/// <summary>
+		/// Parses a public key
+		/// </summary>
+		/// <param name="publicKey">The plain text value of the public key</param>
+		/// <returns></returns>
+		public static PgpPublicKey ReadPublicKey(string publicKey)
+		{
+			if (string.IsNullOrEmpty(publicKey))
+				throw new FileNotFoundException("Public key was not provided");
+
+			return ReadPublicKey(publicKey.GetStream());
+		}
+
+		/// <summary>
+		/// Parses a public key
+		/// </summary>
+		/// <param name="publicKeyFile">The path to the public key file</param>
+		/// <returns></returns>
+		public static PgpPublicKey ReadPublicKey(FileInfo publicKeyFile)
+		{
+			if (!publicKeyFile.Exists)
+				throw new FileNotFoundException($"File {publicKeyFile} was not found");
+			using (FileStream fs = publicKeyFile.OpenRead())
+				return ReadPublicKey(fs);
+		}
+
+		/// <summary>
+		/// Constructs the PublicKeyRingBundle from a file
+		/// </summary>
+		/// <param name="publicKeyFile"></param>
+		/// <returns></returns>
+		/// <exception cref="FileNotFoundException"></exception>
+		public static PgpPublicKeyRingBundle ReadPublicKeyRingBundle(FileInfo publicKeyFile)
+		{
+			if (!publicKeyFile.Exists)
+				throw new FileNotFoundException($"File {publicKeyFile} was not found");
+			using (FileStream fs = publicKeyFile.OpenRead())
+				return ReadPublicKeyRingBundle(fs);
+		}
+
+		/// <summary>
+		/// Opens a key ring file and returns all public keys found.
+		/// </summary>
+		/// <param name="publicKeyStream">Input stream containing the public key contents</param>
+		/// <returns></returns>
+		public static PgpPublicKeyRingBundle ReadPublicKeyRingBundle(Stream publicKeyStream)
+		{
+			using (Stream inputStream = PgpUtilities.GetDecoderStream(publicKeyStream))
+				return new PgpPublicKeyRingBundle(inputStream);
+		}
+
+		/// <summary>
+		/// Returns all public key rings from multiple public key streams
+		/// </summary>
+		/// <param name="publicKeyStreams"></param>
+		/// <returns></returns>
+		public static IEnumerable<PgpPublicKeyRing> ReadAllKeyRings(IEnumerable<Stream> publicKeyStreams)
+		{
+			var publicKeyBundles = publicKeyStreams.Select(ReadPublicKeyRingBundle);
+			return ReadAllKeyRings(publicKeyBundles);
+		}
+
+		/// <summary>
+		/// Returns all public key rings from a public key stream
+		/// </summary>
+		/// <param name="publicKeyStream"></param>
+		/// <returns></returns>
+		public static IEnumerable<PgpPublicKeyRing> ReadAllKeyRings(Stream publicKeyStream)
+		{
+			var publicKeyBundles = ReadPublicKeyRingBundle(publicKeyStream);
+			return publicKeyBundles.GetKeyRings().Cast<PgpPublicKeyRing>();
+		}
+
+		private static IEnumerable<PgpPublicKeyRing> ReadAllKeyRings(
+			IEnumerable<PgpPublicKeyRingBundle> publicKeyRingBundles)
+		{
+			return publicKeyRingBundles.SelectMany(bundle => bundle.GetKeyRings().Cast<PgpPublicKeyRing>());
+		}
+
+		/// <summary>
+		/// Returns the secret key ring bundle from a private key stream
+		/// </summary>
+		/// <param name="privateKeyStream"></param>
+		/// <returns></returns>
+		public static PgpSecretKeyRingBundle ReadSecretKeyRingBundle(Stream privateKeyStream)
+		{
+			using (Stream inputStream = PgpUtilities.GetDecoderStream(privateKeyStream))
+				return new PgpSecretKeyRingBundle(inputStream);
+		}
+
+		/// <summary>
+		/// Finds and returns the public key most suitable for verification in a key ring. Master keys are prioritized
+		/// </summary>
+		/// <param name="publicKeys"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentException"></exception>
+		public static PgpPublicKey FindBestVerificationKey(PgpPublicKeyRing publicKeys)
+		{
+			PgpPublicKey[] keys = publicKeys.GetPublicKeys().Cast<PgpPublicKey>().ToArray();
+
+			// Has Key Flags for signing content
+			PgpPublicKey[] verificationKeys = keys.Where(key => GetSigningScore(key) >= 3).ToArray();
+			// Failsafe, get master key with signing capabilities.
+			if (!verificationKeys.Any())
+				verificationKeys = keys.Where(key => GetSigningScore(key) >= 1).ToArray();
+
+			PgpPublicKey signingKey = verificationKeys.OrderByDescending(GetSigningScore).FirstOrDefault();
+			if (signingKey == null)
+				throw new ArgumentException("No verification keys in keyring");
+
+			return signingKey;
+		}
+
+		/// <summary>
+		/// Finds and returns the public key most suitable for encryption in a key ring. Master keys are prioritized
+		/// </summary>
+		/// <param name="publicKeys"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentException"></exception>
+		public static PgpPublicKey FindBestEncryptionKey(PgpPublicKeyRing publicKeys)
+		{
+			PgpPublicKey[] keys = publicKeys.GetPublicKeys().Cast<PgpPublicKey>().ToArray();
+			// Is encryption key and has the two encryption key flags
+			PgpPublicKey[] encryptKeys = keys.Where(key => GetEncryptionScore(key) >= 4).ToArray();
+			if (!encryptKeys
+				    .Any()) // Failsafe: if no suitable encryption keys are found, get master key with encryption capability
+				encryptKeys = keys.Where(key => GetEncryptionScore(key) >= 3).ToArray();
+			PgpPublicKey encryptionKey = encryptKeys.OrderByDescending(GetEncryptionScore).FirstOrDefault();
+			if (encryptionKey == null)
+				throw new ArgumentException("No encryption keys in keyring");
+			return encryptionKey;
+		}
+
+		/// <summary>
+		/// Finds the first secret key in the key ring suitable for signing. 
+		/// </summary>
+		/// <param name="secretKeyRingBundle">The key ring bundle to search</param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentException">When no rings are suitable for signing</exception>
+		public static PgpSecretKey FindBestSigningKey(PgpSecretKeyRingBundle secretKeyRingBundle)
+		{
+			PgpSecretKeyRing[] keyRings = secretKeyRingBundle.GetKeyRings().Cast<PgpSecretKeyRing>().ToArray();
+
+			var secretKeys = keyRings.SelectMany(ring => ring.GetSecretKeys().Cast<PgpSecretKey>())
+				.OrderByDescending(GetSigningScore).ToArray();
+			
+			if(!secretKeys.Any())
+				throw new ArgumentException("Could not find any signing keys in keyring");
+			return secretKeys.First();
+		}
+
+		/// <summary>
+		/// Checks if the key with the given id is present in the collection of public keys, and if it is, return it.
+		/// </summary>
+		/// <param name="keyId"></param>
+		/// <param name="verificationKeys"></param>
+		/// <param name="verificationKey"></param>
+		/// <returns></returns>
+		public static bool FindPublicKey(long keyId, IEnumerable<PgpPublicKey> verificationKeys,
+			out PgpPublicKey verificationKey)
+		{
+			var foundKeys = verificationKeys.Where(key =>
+				key.KeyId == keyId ||
+				key.GetSignatures().Cast<PgpSignature>().Any(signature => signature.KeyId == keyId)).ToArray();
+			verificationKey = foundKeys.FirstOrDefault();
+			return foundKeys.Any();
+		}
+
+		private static async Task PipeFileContentsAsync(FileInfo file, Stream pOut, int bufSize)
+		{
+			using (FileStream inputStream = file.OpenRead())
+			{
+				byte[] buf = new byte[bufSize];
+
+				int len;
+				while ((len = await inputStream.ReadAsync(buf, 0, buf.Length)) > 0)
+				{
+					await pOut.WriteAsync(buf, 0, len);
+				}
+			}
+		}
+
+		private static void PipeFileContents(FileInfo file, Stream pOut, int bufSize)
+		{
+			using (FileStream inputStream = file.OpenRead())
+			{
+				byte[] buf = new byte[bufSize];
+
+				int len;
+				while ((len = inputStream.Read(buf, 0, buf.Length)) > 0)
+				{
+					pOut.Write(buf, 0, len);
+				}
+			}
+		}
+
+		private static async Task PipeStreamContentsAsync(Stream input, Stream pOut, int bufSize)
+		{
+			byte[] buf = new byte[bufSize];
+
+			int len;
+			while ((len = await input.ReadAsync(buf, 0, buf.Length)) > 0)
+			{
+				await pOut.WriteAsync(buf, 0, len);
+			}
+		}
+
+		private static void PipeStreamContents(Stream input, Stream pOut, int bufSize)
+		{
+			byte[] buf = new byte[bufSize];
+
+			int len;
+			while ((len = input.Read(buf, 0, buf.Length)) > 0)
+			{
+				pOut.Write(buf, 0, len);
+			}
+		}
+
+		private const int ReadAhead = 60;
+
+		private static bool IsPossiblyBase64(
+			int ch)
+		{
+			return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+			                              || ch >= '0' && ch <= '9' || ch == '+' || ch == '/'
+			                              || ch == '\r' || ch == '\n';
+		}
+
+		/// <summary>
+		/// Return either an ArmoredInputStream or a BcpgInputStream based on whether
+		/// the initial characters of the stream are binary PGP encodings or not.
+		/// </summary>
+		public static Stream GetDecoderStream(
+			Stream inputStream)
+		{
+			// TODO Remove this restriction?
+			if (!inputStream.CanSeek)
+				throw new ArgumentException("inputStream must be seek-able", nameof(inputStream));
+
+			long markedPos = inputStream.Position;
+
+			int ch = inputStream.ReadByte();
+			if ((ch & 0x80) != 0)
+			{
+				inputStream.Position = markedPos;
+
+				return inputStream;
+			}
+
+			if (!IsPossiblyBase64(ch))
+			{
+				inputStream.Position = markedPos;
+
+				return new ArmoredInputStream(inputStream);
+			}
+
+			byte[] buf = new byte[ReadAhead];
+			int count = 1;
+			int index = 1;
+
+			buf[0] = (byte)ch;
+			while (count != ReadAhead && (ch = inputStream.ReadByte()) >= 0)
+			{
+				if (!IsPossiblyBase64(ch))
+				{
+					inputStream.Position = markedPos;
+
+					return new ArmoredInputStream(inputStream);
+				}
+
+				if (ch != '\n' && ch != '\r')
+				{
+					buf[index++] = (byte)ch;
+				}
+
+				count++;
+			}
+
+			inputStream.Position = markedPos;
+
+			//
+			// nothing but new lines, little else, assume regular armoring
+			//
+			if (count < 4)
+			{
+				return new ArmoredInputStream(inputStream);
+			}
+
+			//
+			// test our non-blank data
+			//
+			byte[] firstBlock = new byte[8];
+			Array.Copy(buf, 0, firstBlock, 0, firstBlock.Length);
+			byte[] decoded = Base64.Decode(firstBlock);
+
+			//
+			// it's a base64 PGP block.
+			//
+			bool hasHeaders = (decoded[0] & 0x80) == 0;
+
+			return new ArmoredInputStream(inputStream, hasHeaders);
+		}
+
+		public static PgpPublicKeyEncryptedData ExtractPublicKeyEncryptedData(Stream encodedFile)
+		{
+			PgpEncryptedDataList encryptedDataList = GetEncryptedDataList(encodedFile);
+			return ExtractPublicKey(encryptedDataList);
+		}
+
+		public static PgpPublicKeyEncryptedData ExtractPublicKeyEncryptedData(PgpEncryptedDataList encryptedDataList)
+		{
+			return ExtractPublicKey(encryptedDataList);
+		}
+
+		public static PgpObject ProcessCompressedMessage(PgpObject message)
+		{
+			PgpCompressedData compressedData = (PgpCompressedData)message;
+			Stream compressedDataStream = compressedData.GetDataStream();
+			PgpObjectFactory compressedFactory = new PgpObjectFactory(compressedDataStream);
+			message = CheckForOnePassSignatureList(compressedFactory);
+			return message;
+		}
+
+		public static PgpObject CheckForOnePassSignatureList(PgpObjectFactory compressedFactory)
+		{
+			var message = compressedFactory.NextPgpObject();
+			if (message is PgpOnePassSignatureList)
+			{
+				message = compressedFactory.NextPgpObject();
+			}
+
+			return message;
+		}
+
+		public static PgpObject SkipSignatureList(PgpObjectFactory compressedFactory)
+		{
+			var message = compressedFactory.NextPgpObject();
+			while (message is PgpOnePassSignatureList || message is PgpSignatureList)
+			{
+				message = compressedFactory.NextPgpObject();
+			}
+
+			return message;
+		}
+
+
+		public static PgpObjectFactory GetClearDataStream(PgpPrivateKey privateKey,
+			PgpPublicKeyEncryptedData publicKeyEncryptedData)
+		{
+			Stream clearStream = publicKeyEncryptedData.GetDataStream(privateKey);
+			PgpObjectFactory clearFactory = new PgpObjectFactory(clearStream);
+			return clearFactory;
+		}
+
+		public static PgpPublicKeyEncryptedData ExtractPublicKey(PgpEncryptedDataList encryptedDataList)
+		{
+			return encryptedDataList.GetEncryptedDataObjects().Cast<PgpPublicKeyEncryptedData>()
+				.FirstOrDefault(encryptedData => encryptedData != null);
+		}
+
+		public static PgpEncryptedDataList GetEncryptedDataList(Stream encodedFile)
+		{
+			var factory = new PgpObjectFactory(encodedFile);
+			PgpObject pgpObject = factory.NextPgpObject();
+
+			PgpEncryptedDataList encryptedDataList;
+
+			if (pgpObject is PgpEncryptedDataList dataList)
+			{
+				encryptedDataList = dataList;
+			}
+			else
+			{
+				encryptedDataList = (PgpEncryptedDataList)factory.NextPgpObject();
+			}
+
+			return encryptedDataList;
+		}
+
+		public static PgpOnePassSignatureList GetPgpOnePassSignatureList(Stream encodedFile)
+		{
+			var factory = new PgpObjectFactory(encodedFile);
+			PgpObject pgpObject = factory.NextPgpObject();
+
+			PgpOnePassSignatureList pgpOnePassSignatureList;
+
+			if (pgpObject is PgpOnePassSignatureList onePassSignatureList)
+			{
+				pgpOnePassSignatureList = onePassSignatureList;
+			}
+			else
+			{
+				pgpOnePassSignatureList = (PgpOnePassSignatureList)factory.NextPgpObject();
+			}
+
+			return pgpOnePassSignatureList;
+		}
+
+		/// <summary>
+		/// Scores the public key for how suitable it is as an encryption key
+		/// Master key += 1
+		/// IsEncryptionKey += 2
+		/// Either of the encryption flags += 1 (for each)
+		/// Highest score is 5
+		/// </summary>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		private static int GetEncryptionScore(PgpPublicKey key)
+		{
+			int score = 0;
+			if (key.IsMasterKey)
+				score += 1;
+			if (key.IsEncryptionKey)
+				score += 2;
+			PgpSignature[] signatures = key.GetSignatures().Cast<PgpSignature>()
+				.Where(signature => signature.HasSubpackets).ToArray();
+
+			if (signatures.Any(signature =>
+				    (signature.GetHashedSubPackets().GetKeyFlags() & KeyFlags.EncryptComms) > 0))
+				score += 1;
+			if (signatures.Any(signature =>
+				    (signature.GetHashedSubPackets().GetKeyFlags() & KeyFlags.EncryptStorage) > 0))
+				score += 1;
+			return score;
+		}
+
+		/// <summary>
+		/// Scores the public key for how suitable it is as a verification key
+		/// Master key += 1
+		/// Signing key flag += 2
+		/// Highest score is 3
+		/// </summary>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		private static int GetSigningScore(PgpPublicKey key)
+		{
+			int score = 0;
+			if (key.IsMasterKey)
+				score += 1;
+			var signatures = key.GetSignatures().Cast<PgpSignature>();
+			if (signatures.Any(signature => signature.HasSubpackets &&
+			                                (signature.GetHashedSubPackets().GetKeyFlags() & KeyFlags.SignData) > 0))
+				score += 2;
+			return score;
+		}
+
+		/// <summary>
+		/// Scores the secret key for how suitable it is as a signing key
+		/// Master key += 1
+		/// IsSigningKey += 2
+		/// Signing key flag += 2
+		/// Highest score is 5
+		/// </summary>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		private static int GetSigningScore(PgpSecretKey key)
+		{
+			int score = 0;
+			if (key.IsSigningKey)
+				score += 2;
+			score += GetSigningScore(key.PublicKey);
+			return score;
+		}
+	}
 }


### PR DESCRIPTION
Library will look for appropriate KeyFlags for encryption and signing keys respectively. Some code cleanup.

So @mattosaurus.. about that rewrite 😅

The commit started as simply just getting the library to find and use subkeys in the keyrings appropriately. It grew, however, as I saw some possibilities for refactoring, clarity, and other "small" changes which ended up at ***looks at commit*** ~7 000 additions and deletions..

I tried to leave the Interfaces alone as to avoid breaking changes, but it still remains a large amount of changes. I probably should have divided it up in more "bite-sized" commits, but alas, here we are.
Also, as far as I can see, it does pass the unit tests. 

Hope you will take a look!