### PR TITLE
Fix incompatibility w/ Portable.BouncyCastle 1.9.0

### DIFF
--- a/PgpCore/CompositeDisposable.cs
+++ b/PgpCore/CompositeDisposable.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace PgpCore
+{
+    /// <seealso href="https://github.com/dotnet/reactive/blob/main/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs">
+    /// Simplified adaptation from System.Reactive.
+    /// </seealso>
+    internal sealed class CompositeDisposable : IDisposable
+    {
+        private readonly ConcurrentQueue<IDisposable> _disposables = new ConcurrentQueue<IDisposable>();
+
+        public void Add(IDisposable disposable)
+        {
+            if (disposable == null)
+                throw new ArgumentNullException(nameof(disposable));
+
+            _disposables.Enqueue(disposable);
+        }
+
+        public void Dispose()
+        {
+            while (_disposables.TryDequeue(out IDisposable disposable))
+                disposable.Dispose();
+        }
+    }
+}

--- a/PgpCore/DisposableExtensions.cs
+++ b/PgpCore/DisposableExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace PgpCore
+{
+    internal static class DisposableExtensions
+    {
+        /// <seealso href="https://github.com/reactiveui/ReactiveUI/blob/main/src/ReactiveUI/Mixins/DisposableMixins.cs#L28">
+        /// Adapted from ReactiveUI.
+        /// </seealso>
+        public static T DisposeWith<T>(this T @this, CompositeDisposable disposables)
+            where T : IDisposable
+        {
+            if (@this == null)
+                throw new ArgumentNullException(nameof(@this));
+            if (disposables == null)
+                throw new ArgumentNullException(nameof(disposables));
+
+            disposables.Add(@this);
+            return @this;
+        }
+    }
+}


### PR DESCRIPTION
This resolves the "Cannot Access a closed stream" error during decryption by delaying disposal of all streams returned from `GetDataStream`.

Fixes #140

Adapted from #155