### PR TITLE
Rework to support usage of encryption subkeys

### DIFF
--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -373,7 +373,7 @@ namespace PgpCore
 		{
 			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in PublicKeyRings)
 			{
-				publicKeyRing.UseEncryptionKey(keyId);
+				publicKeyRing.UsePreferredEncryptionKey(keyId);
 			}
 		}
 
@@ -409,14 +409,13 @@ namespace PgpCore
 			else
 			{
 				// Need to consume the stream into a list before it is closed (can happen because of lazy instantiation).
-				PgpPublicKeyRing[] publicKeyRingsConsumed = publicKeyRings.ToArray();
-				_publicKeyRingsWithPreferredKey = new Lazy<IEnumerable<PgpPublicKeyRingWithPreferredKey>>(() => publicKeyRingsConsumed.Select(keyRing => new PgpPublicKeyRingWithPreferredKey(keyRing)));
+				_publicKeyRingsWithPreferredKey = new Lazy<IEnumerable<PgpPublicKeyRingWithPreferredKey>>(() => publicKeyRings.Select(keyRing => new PgpPublicKeyRingWithPreferredKey(keyRing)).ToArray());
 				_masterKey = new Lazy<PgpPublicKey>(() =>
-					Utilities.FindMasterKey(publicKeyRingsConsumed.First()));
+					Utilities.FindMasterKey(publicKeyRings.First()));
 				_encryptKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-					publicKeyRingsConsumed.Select(Utilities.FindBestEncryptionKey).ToArray());
+					publicKeyRings.Select(Utilities.FindBestEncryptionKey).ToArray());
 				_verificationKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-					publicKeyRingsConsumed.Select(Utilities.FindBestVerificationKey).ToArray());
+					publicKeyRings.Select(Utilities.FindBestVerificationKey).ToArray());
 			}
 
 			if (_secretKeys != null)

--- a/PgpCore/EncryptionKeys.cs
+++ b/PgpCore/EncryptionKeys.cs
@@ -10,6 +10,7 @@ namespace PgpCore
 	{
 		#region Instance Members (Public)
 
+		public IEnumerable<PgpPublicKeyRingWithPreferredKey> PublicKeyRings => _publicKeyRingsWithPreferredKey.Value;
 		public IEnumerable<PgpPublicKey> EncryptKeys => _encryptKeys.Value;
 		public IEnumerable<PgpPublicKey> VerificationKeys => _verificationKeys.Value;
 		public PgpPrivateKey SigningPrivateKey => _signingPrivateKey.Value;
@@ -33,6 +34,7 @@ namespace PgpCore
 		private Lazy<PgpPrivateKey> _signingPrivateKey;
 		private Lazy<PgpSecretKey> _signingSecretKey;
 		private Lazy<PgpSecretKeyRingBundle> _secretKeys;
+		private Lazy<IEnumerable<PgpPublicKeyRingWithPreferredKey>> _publicKeyRingsWithPreferredKey;
 
 		#endregion Instance Members (Private)
 
@@ -362,6 +364,19 @@ namespace PgpCore
 			return pgpSecKey.ExtractPrivateKey(_passPhrase.ToCharArray());
 		}
 
+		/// <summary>
+		/// This method will try to find the key with the given keyId in a key ring and set it as the preferred key.
+		/// If it cannot find the key, it will not change the preferred key.
+		/// </summary>
+		/// <param name="keyId">The keyId to find.</param>
+		public void UseEncrytionKey(long keyId)
+		{
+			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in PublicKeyRings)
+			{
+				publicKeyRing.UseEncryptionKey(keyId);
+			}
+		}
+
 		#endregion Public Methods
 
 		#region Private Key
@@ -389,16 +404,19 @@ namespace PgpCore
 				_masterKey = new Lazy<PgpPublicKey>(() => null);
 				_encryptKeys = new Lazy<IEnumerable<PgpPublicKey>>(() => null);
 				_verificationKeys = new Lazy<IEnumerable<PgpPublicKey>>(() => null);
+				_publicKeyRingsWithPreferredKey = new Lazy<IEnumerable<PgpPublicKeyRingWithPreferredKey>>(() => null);
 			}
 			else
 			{
 				// Need to consume the stream into a list before it is closed (can happen because of lazy instantiation).
+				PgpPublicKeyRing[] publicKeyRingsConsumed = publicKeyRings.ToArray();
+				_publicKeyRingsWithPreferredKey = new Lazy<IEnumerable<PgpPublicKeyRingWithPreferredKey>>(() => publicKeyRingsConsumed.Select(keyRing => new PgpPublicKeyRingWithPreferredKey(keyRing)));
 				_masterKey = new Lazy<PgpPublicKey>(() =>
-					Utilities.FindMasterKey(publicKeyRings.First()));
+					Utilities.FindMasterKey(publicKeyRingsConsumed.First()));
 				_encryptKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-					publicKeyRings.Select(Utilities.FindBestEncryptionKey).ToArray());
+					publicKeyRingsConsumed.Select(Utilities.FindBestEncryptionKey).ToArray());
 				_verificationKeys = new Lazy<IEnumerable<PgpPublicKey>>(() =>
-					publicKeyRings.Select(Utilities.FindBestVerificationKey).ToArray());
+					publicKeyRingsConsumed.Select(Utilities.FindBestVerificationKey).ToArray());
 			}
 
 			if (_secretKeys != null)

--- a/PgpCore/IEncryptionKeys.cs
+++ b/PgpCore/IEncryptionKeys.cs
@@ -12,6 +12,7 @@ namespace PgpCore
     /// </summary>
     public interface IEncryptionKeys
     {
+        IEnumerable<PgpPublicKeyRingWithPreferredKey> PublicKeyRings { get; }
         IEnumerable<PgpPublicKey> EncryptKeys { get; }
         IEnumerable<PgpPublicKey> VerificationKeys { get; }
         PgpPrivateKey SigningPrivateKey { get; }

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -670,6 +670,11 @@ namespace PgpCore
 			PgpEncryptedDataGenerator pk =
 				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
 
+			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in EncryptionKeys.PublicKeyRings)
+			{
+				PgpPublicKey publicKey = publicKeyRing.PreferredKey ?? Utilities.FindBestEncryptionKey(publicKeyRing.PgpPublicKeyRing);
+				pk.AddMethod(publicKey);
+			}
 			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
 			{
 				pk.AddMethod(publicKey);

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -552,8 +552,9 @@ namespace PgpCore
 
 			PgpEncryptedDataGenerator pk =
 				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
-			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
+			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in EncryptionKeys.PublicKeyRings)
 			{
+				PgpPublicKey publicKey = publicKeyRing.PreferredEncryptionKey ?? publicKeyRing.DefaultEncryptionKey;
 				pk.AddMethod(publicKey);
 			}
 
@@ -672,11 +673,7 @@ namespace PgpCore
 
 			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in EncryptionKeys.PublicKeyRings)
 			{
-				PgpPublicKey publicKey = publicKeyRing.PreferredKey ?? Utilities.FindBestEncryptionKey(publicKeyRing.PgpPublicKeyRing);
-				pk.AddMethod(publicKey);
-			}
-			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
-			{
+				PgpPublicKey publicKey = publicKeyRing.PreferredEncryptionKey ?? publicKeyRing.DefaultEncryptionKey;
 				pk.AddMethod(publicKey);
 			}
 
@@ -5674,7 +5671,7 @@ namespace PgpCore
 				var keyIdToVerify = publicKeyEncryptedData.KeyId;
 				// If we encounter an encrypted packet, verify with the encryption keys used instead
 				// TODO does this even make sense? maybe throw exception instead, or try to decrypt first
-				verified = Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.EncryptKeys, out PgpPublicKey _);
+				verified = Utilities.FindPublicKeyInKeyRings(keyIdToVerify, EncryptionKeys.PublicKeyRings.Select(keyRing => keyRing.PgpPublicKeyRing), out PgpPublicKey _);
 				
 			}
 			else if (pgpObject is PgpOnePassSignatureList onePassSignatureList)
@@ -5817,7 +5814,7 @@ namespace PgpCore
 
 				// If we encounter an encrypted packet, verify the encryption key used instead
 				// TODO does this even make sense? maybe throw exception instead, or try to decrypt first
-				if (Utilities.FindPublicKey(keyIdToVerify, EncryptionKeys.EncryptKeys, out PgpPublicKey _))
+				if (Utilities.FindPublicKeyInKeyRings(keyIdToVerify, EncryptionKeys.PublicKeyRings.Select(keyRing => keyRing.PgpPublicKeyRing), out PgpPublicKey _))
 				{
 					verified = true;
 				}
@@ -6130,8 +6127,9 @@ namespace PgpCore
 			var encryptedDataGenerator =
 				new PgpEncryptedDataGenerator(SymmetricKeyAlgorithm, withIntegrityCheck, new SecureRandom());
 
-			foreach (PgpPublicKey publicKey in EncryptionKeys.EncryptKeys)
+			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in EncryptionKeys.PublicKeyRings)
 			{
+				PgpPublicKey publicKey = publicKeyRing.PreferredEncryptionKey ?? publicKeyRing.DefaultEncryptionKey;
 				encryptedDataGenerator.AddMethod(publicKey);
 			}
 

--- a/PgpCore/PgpPublicKeyRingWithPreferredKey.cs
+++ b/PgpCore/PgpPublicKeyRingWithPreferredKey.cs
@@ -1,32 +1,45 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 
 namespace PgpCore
 {
+    /// <summary>
+    /// A wrapper class for <see cref="PgpPublicKeyRing"/> that also keeps track of a preferred <see cref="PgpPublicKey"/> to be used for encryption.
+    /// </summary>
     public class PgpPublicKeyRingWithPreferredKey
     {
         public PgpPublicKeyRing PgpPublicKeyRing { get; set; }
-        public PgpPublicKey PreferredKey { get; private set; } = null;
+        public PgpPublicKey PreferredEncryptionKey { get; private set; } = null;
+        public PgpPublicKey DefaultEncryptionKey => _defaultEncryptionKey.Value;
+
+        private Lazy<PgpPublicKey> _defaultEncryptionKey;
+        private Lazy<IEnumerable<PgpPublicKey>> _encryptionKeys;
 
         public PgpPublicKeyRingWithPreferredKey(PgpPublicKeyRing publicKeyRing)
         {
             PgpPublicKeyRing = publicKeyRing;
-        }
-        
-        public PgpPublicKeyRingWithPreferredKey(PgpPublicKeyRing publicKeyRing, long preferredKeyId)
-        {
-            PgpPublicKeyRing = publicKeyRing;
-            UseEncryptionKey(preferredKeyId);
+            _defaultEncryptionKey = new Lazy<PgpPublicKey>(() => Utilities.FindBestEncryptionKey(PgpPublicKeyRing));
+            _encryptionKeys = new Lazy<IEnumerable<PgpPublicKey>>(() => PgpPublicKeyRing.GetPublicKeys().Where(key => key.IsEncryptionKey));
         }
 
         /// <summary>
-        /// This method will try to find the key with the given keyId and set it as the preferred key.
-        /// If it cannot find the key, it will not change the preferred key.
+        /// Try to find the key with the given keyId and set it as the preferred encryption key.
+        /// If no key is found, the preferred key is not changed.
         /// </summary>
         /// <param name="keyId">The keyId to find.</param>
-        public void UseEncryptionKey(long keyId)
+        public void UsePreferredEncryptionKey(long? keyId)
         {
-            PreferredKey = PgpPublicKeyRing.GetPublicKeys().FirstOrDefault(key => key.KeyId == keyId && key.IsEncryptionKey) ?? PreferredKey;
+            PreferredEncryptionKey = _encryptionKeys.Value.FirstOrDefault(key => key.KeyId == keyId) ?? PreferredEncryptionKey;
+        }
+
+        /// <summary>
+        /// Clear the preferred encryption key.
+        /// </summary>
+        public void ClearPreferredEncryptionKey()
+        {
+            PreferredEncryptionKey = null;
         }
     }
 }

--- a/PgpCore/PgpPublicKeyRingWithPreferredKey.cs
+++ b/PgpCore/PgpPublicKeyRingWithPreferredKey.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Org.BouncyCastle.Bcpg.OpenPgp;
+
+namespace PgpCore
+{
+    public class PgpPublicKeyRingWithPreferredKey
+    {
+        public PgpPublicKeyRing PgpPublicKeyRing { get; set; }
+        public PgpPublicKey PreferredKey { get; private set; } = null;
+
+        public PgpPublicKeyRingWithPreferredKey(PgpPublicKeyRing publicKeyRing)
+        {
+            PgpPublicKeyRing = publicKeyRing;
+        }
+        
+        public PgpPublicKeyRingWithPreferredKey(PgpPublicKeyRing publicKeyRing, long preferredKeyId)
+        {
+            PgpPublicKeyRing = publicKeyRing;
+            UseEncryptionKey(preferredKeyId);
+        }
+
+        /// <summary>
+        /// This method will try to find the key with the given keyId and set it as the preferred key.
+        /// If it cannot find the key, it will not change the preferred key.
+        /// </summary>
+        /// <param name="keyId">The keyId to find.</param>
+        public void UseEncryptionKey(long keyId)
+        {
+            PreferredKey = PgpPublicKeyRing.GetPublicKeys().FirstOrDefault(key => key.KeyId == keyId && key.IsEncryptionKey) ?? PreferredKey;
+        }
+    }
+}

--- a/PgpCore/Utilities.cs
+++ b/PgpCore/Utilities.cs
@@ -640,6 +640,21 @@ namespace PgpCore
 			return foundKeys.Any();
 		}
 
+		public static bool FindPublicKeyInKeyRings(long keyId, IEnumerable<PgpPublicKeyRing> publicKeyRings,
+			out PgpPublicKey verificationKey)
+		{
+			verificationKey = null;
+
+			foreach (PgpPublicKeyRing publicKeyRing in publicKeyRings)
+			{
+				var verificationKeys = publicKeyRing.GetPublicKeys();
+				if (FindPublicKey(keyId, verificationKeys, out verificationKey))
+					return true;
+			}
+
+			return false;
+		}
+
 		private static async Task PipeFileContentsAsync(FileInfo file, Stream pOut, int bufSize)
 		{
 			using (FileStream inputStream = file.OpenRead())


### PR DESCRIPTION
#238 (partly)

So, I've changed how public keys are managed in `EncryptionKeys` and how they are used in Encryption and some Verification in `PGP`.

Summary of the main changes in this PR:
- Every public key ring is now stored as a collection of a new wrapper class - `PgpPublicKeyRingWithPreferredKey` (I'm still open for better name suggestions). This class stores the public key ring, the default key (using the already existing algorithm to find the 'best' key) and a preferred key, which can be set by the user using `EncryptionKeys.UseEncryptionKey(_some_keyId_)`
- In the encryption methods, for every known public key ring (a.k.a. recipient), PGP uses the preferred key if it's set, otherwise the default key.
- When verifying encrypted data, it will look for a matching key in any of the known keys in the key rings.

I think more improvements can be made regarding the handling of public keys, but I think this PR could give an indication of a possible direction.