### PR TITLE
Minor correction of XML comments

### DIFF
--- a/PgpCore/PGP.EncryptAsync.cs
+++ b/PgpCore/PGP.EncryptAsync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg.OpenPgp;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Security;
 using System;
@@ -26,7 +26,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task EncryptAsync(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -63,7 +63,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task EncryptAsync(
             Stream inputStream,
             Stream outputStream,
@@ -131,7 +131,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task<string> EncryptAsync(
             string input,
             bool armor = true,
@@ -174,7 +174,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task EncryptAndSignAsync(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -222,7 +222,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task EncryptAndSignAsync(
             Stream inputStream,
             Stream outputStream,
@@ -267,7 +267,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task<string> EncryptAndSignAsync(
             string input,
             bool armor = true,

--- a/PgpCore/PGP.EncryptSync.cs
+++ b/PgpCore/PGP.EncryptSync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg.OpenPgp;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Security;
 using PgpCore.Helpers;
@@ -24,7 +24,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void Encrypt(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -61,7 +61,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void Encrypt(
             Stream inputStream,
             Stream outputStream,
@@ -130,7 +130,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True, to perform integrity packet check on input file. Otherwise, false</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public string Encrypt(
             string input,
             bool armor = true,
@@ -170,8 +170,9 @@ namespace PgpCore
         /// <param name="outputFile">Output PGP encrypted and signed file</param>
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
+        /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void EncryptAndSign(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -218,7 +219,7 @@ namespace PgpCore
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void EncryptAndSign(
             Stream inputStream,
             Stream outputStream,
@@ -258,10 +259,11 @@ namespace PgpCore
         /// Encrypt and sign the string
         /// </summary>
         /// <param name="input">Plain string to be encrypted and signed</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public string EncryptAndSign(
             string input,
             bool armor = true,

--- a/PgpCore/PGP.InspectAsync.cs
+++ b/PgpCore/PGP.InspectAsync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg;
+using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 using Org.BouncyCastle.Utilities.Zlib;
 using PgpCore.Abstractions;
@@ -14,7 +14,7 @@ namespace PgpCore
     public partial class PGP : IInspectAsync
     {
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="inputStream">The input stream containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>
@@ -39,7 +39,7 @@ namespace PgpCore
         }
 
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="inputFile">The input file containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>
@@ -57,7 +57,7 @@ namespace PgpCore
         }
 
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="input">The input string containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>

--- a/PgpCore/PGP.InspectSync.cs
+++ b/PgpCore/PGP.InspectSync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg;
+using Org.BouncyCastle.Bcpg;
 using Org.BouncyCastle.Bcpg.OpenPgp;
 using Org.BouncyCastle.Utilities.Zlib;
 using PgpCore.Abstractions;
@@ -19,7 +19,7 @@ namespace PgpCore
     public partial class PGP : IInspectSync
     {
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="inputStream">The input stream containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>
@@ -159,7 +159,7 @@ namespace PgpCore
         }
 
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="inputFile">The input file containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>
@@ -177,7 +177,7 @@ namespace PgpCore
         }
 
         /// <summary>
-        /// Inspect an arbitary PGP message returning information about the message
+        /// Inspect an arbitrary PGP message returning information about the message
         /// </summary>
         /// <param name="input">The input string containing the PGP message</param>
         /// <returns>Returns an object containing details of the provided PGP message</returns>

--- a/PgpCore/PGP.RecipientsSync.cs
+++ b/PgpCore/PGP.RecipientsSync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg.OpenPgp;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using PgpCore.Abstractions;
 using PgpCore.Extensions;
 using PgpCore.Helpers;
@@ -17,7 +17,7 @@ namespace PgpCore
         /// <summary>
         /// PGP get a recipients keys id of an encrypted file.
         /// </summary>
-        /// <param name="inputFilePath">PGP encrypted data file path</param>
+        /// <param name="inputFileInfo">PGP encrypted data file path</param>
         /// <returns>Enumerable of public key ids. Value "0" means that the recipient is hidden.</returns>
         public IEnumerable<long> GetFileRecipients(FileInfo inputFileInfo)
         {

--- a/PgpCore/PGP.SignAsync.cs
+++ b/PgpCore/PGP.SignAsync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg;
+using Org.BouncyCastle.Bcpg;
 using PgpCore.Abstractions;
 using PgpCore.Extensions;
 using PgpCore.Helpers;
@@ -21,6 +21,7 @@ namespace PgpCore
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task SignAsync(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -65,6 +66,7 @@ namespace PgpCore
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the stream name if the stream is a FileStream, otherwise to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task SignAsync(
             Stream inputStream,
             Stream outputStream,
@@ -106,6 +108,7 @@ namespace PgpCore
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public async Task<string> SignAsync(
             string input,
             bool armor = true,

--- a/PgpCore/PGP.SignSync.cs
+++ b/PgpCore/PGP.SignSync.cs
@@ -1,4 +1,4 @@
-﻿using Org.BouncyCastle.Bcpg;
+using Org.BouncyCastle.Bcpg;
 using PgpCore.Abstractions;
 using PgpCore.Extensions;
 using PgpCore.Helpers;
@@ -21,7 +21,7 @@ namespace PgpCore
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void Sign(
             FileInfo inputFile,
             FileInfo outputFile,
@@ -66,7 +66,7 @@ namespace PgpCore
         /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to the stream name if the stream is a FileStream, otherwise to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public void Sign(
             Stream inputStream,
             Stream outputStream,
@@ -105,9 +105,10 @@ namespace PgpCore
         /// Sign the string
         /// </summary>
         /// <param name="input">Plain string to be signed</param>
+        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
-        /// <param name="oldFormat">True, to use old format for encryption if you need compatability with PGP 2.6.x. Otherwise, false</param>
+        /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>
         public string Sign(
             string input,
             bool armor = true,


### PR DESCRIPTION
## Description

Hi,
This pull request includes minor adjustments in C# code related to XML comments. The changes mainly concern minor typos and adding missing comments for parameters.
Thank you in advance  for taking the time to review this pull request. 
Best regards,
Aymeric

## Changes:

-  Correction of minor typos in XML comments.
    -  "compatability" -> "compatibility"
    -  "arbitary" -> "arbitrary"
-  Added missing <param> tags.