### PR TITLE
Update readme to fix GenerateKey example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Generate a new public and private key for the provided username and password.
 using (PGP pgp = new PGP())
 {
 	// Generate keys
-	pgp.GenerateKey(@"C:\TEMP\Keys\public.asc", @"C:\TEMP\Keys\private.asc", "email@email.com", "password");
+	pgp.GenerateKey(new FileInfo(@"C:\TEMP\Keys\public.asc"), new FileInfo(@"C:\TEMP\Keys\private.asc"), "email@email.com", "password");
 }
 ```
 #### Inspect


### PR DESCRIPTION
The given example for GenerateKey doesn't work if copy-pasted. 
The error:
`Argument 1: cannot convert from 'string' to 'System.IO.FileInfo'	ImportExport.EncryptionHelper`

I've updated the readme to pass a FileInfo object into the call instead of a string
