### PR TITLE
Minor correction of XML comments and method renaming (UseEncrytionKey to UseEncryptionKey)

### DIFF
--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -1101,7 +1101,7 @@ namespace PgpCore.Tests
             foreach (long keyId in keyIdsInPublicKeyRing)
             {
                 // Act
-                encryptionKeys.UseEncrytionKey(keyId);
+                encryptionKeys.UseEncryptionKey(keyId);
                 using (Stream inputFileStream = testFactory.ContentStream)
                 using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
                     pgpEncrypt.EncryptStream(inputFileStream, outputFileStream);
@@ -1300,7 +1300,7 @@ namespace PgpCore.Tests
                 .Where(key => key.IsEncryptionKey).Select(key => key.KeyId).ToArray();
             foreach (long keyId in keyIdsInPublicKeyRing)
             {
-                encryptionKeys.UseEncrytionKey(keyId);
+                encryptionKeys.UseEncryptionKey(keyId);
                 using (Stream inputFileStream = testFactory.ContentStream)
                 using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
                     pgp.EncryptStreamAndSign(inputFileStream, outputFileStream);

--- a/PgpCore/Models/EncryptionKeys.cs
+++ b/PgpCore/Models/EncryptionKeys.cs
@@ -376,7 +376,7 @@ namespace PgpCore
 		/// If it cannot find the key, it will not change the preferred key.
 		/// </summary>
 		/// <param name="keyId">The keyId to find.</param>
-		public void UseEncrytionKey(long keyId)
+		public void UseEncryptionKey(long keyId)
 		{
 			foreach (PgpPublicKeyRingWithPreferredKey publicKeyRing in PublicKeyRings)
 			{

--- a/PgpCore/PGP.EncryptSync.cs
+++ b/PgpCore/PGP.EncryptSync.cs
@@ -257,7 +257,6 @@ namespace PgpCore
         /// Encrypt and sign the string
         /// </summary>
         /// <param name="input">Plain string to be encrypted and signed</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="withIntegrityCheck">True to include integrity packet during signing</param>
         /// <param name="name">Name of encrypted file in message, defaults to the input file name</param>
         /// <param name="headers">Optional headers to be added to the output</param>

--- a/PgpCore/PGP.SignAsync.cs
+++ b/PgpCore/PGP.SignAsync.cs
@@ -105,7 +105,6 @@ namespace PgpCore
         /// Sign the string
         /// </summary>
         /// <param name="input">Plain string to be signed</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
         /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>

--- a/PgpCore/PGP.SignSync.cs
+++ b/PgpCore/PGP.SignSync.cs
@@ -105,7 +105,6 @@ namespace PgpCore
         /// Sign the string
         /// </summary>
         /// <param name="input">Plain string to be signed</param>
-        /// <param name="armor">True, means a binary data representation as an ASCII-only text. Otherwise, false</param>
         /// <param name="name">Name of signed file in message, defaults to "name"</param>
         /// <param name="headers">Optional headers to be added to the output</param>
         /// <param name="oldFormat">True, to use old format for encryption if you need compatibility with PGP 2.6.x. Otherwise, false</param>


### PR DESCRIPTION
### Description

Hi,

This pull request addresses some minor code adjustments in C# code and XML comments.
Thank you for your attention to these changes.

Best regards,
Aymeric

## Changes

- Removed unnecessary `armor` parameter from the method documentation.
- Renamed the method `UseEncrytionKey` to `UseEncryptionKey`.

