### PR TITLE
Implemented support for symmetric encryption and decryption

### DIFF
--- a/PgpCore.Tests/PgpCore.Tests.csproj
+++ b/PgpCore.Tests/PgpCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.File.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.File.cs
@@ -113,7 +113,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public async Task DecryptAsync_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -144,7 +144,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public async Task DecryptAsync_DecryptBinaryEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -176,8 +176,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -207,8 +207,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -239,8 +239,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -273,8 +273,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -308,7 +308,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -336,7 +336,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.File.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.File.cs
@@ -18,13 +18,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -48,6 +49,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEmptyEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -57,8 +59,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Create empty file
             testFactory.ContentFileInfo.Create().Close();
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -82,13 +84,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptBinaryEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -116,8 +119,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -147,8 +150,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -179,8 +182,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -210,8 +213,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -242,8 +245,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -276,8 +279,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -310,8 +313,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Null
@@ -338,8 +341,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Safer
@@ -364,6 +367,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedWithMultipleKeys_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -378,7 +382,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -408,6 +412,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptSignedAndEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -417,7 +422,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
             EncryptionKeys encryptionAndSigningKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory2.PrivateKeyFileInfo, testFactory2.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncryptAndSign = new PGP(encryptionAndSigningKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -441,13 +446,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptUnencryptedMessage_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             File.WriteAllText(testFactory.ContentFileInfo.FullName, testFactory.Content);
 
@@ -469,6 +475,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange
@@ -477,7 +484,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -514,7 +521,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 password
                 );
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, password);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -539,6 +546,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAndVerifyAsync_DecryptSignedAndEncryptedMessage_ShouldDecryptAndVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -574,6 +582,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAndVerifyAsync_DecryptSignedAndEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.Stream.cs
@@ -18,13 +18,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -51,13 +52,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEmptyEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -84,13 +86,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptBinaryEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -121,8 +124,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -155,8 +158,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -190,8 +193,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -224,8 +227,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -259,8 +262,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -297,8 +300,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -335,8 +338,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Null
@@ -365,8 +368,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Safer
@@ -393,6 +396,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedWithMultipleKeys_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -407,7 +411,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -442,6 +446,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptSignedAndEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -451,7 +456,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
             EncryptionKeys encryptionAndSigningKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory2.PrivateKeyStream, testFactory2.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncryptAndSign = new PGP(encryptionAndSigningKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -478,13 +483,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptUnencryptedMessage_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             File.WriteAllText(testFactory.ContentFileInfo.FullName, testFactory.Content);
 
@@ -508,6 +514,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAsync_DecryptEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange
@@ -516,7 +523,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -544,6 +551,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAndVerifyAsync_DecryptSignedAndEncryptedMessage_ShouldDecryptAndVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -582,6 +590,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task DecryptAndVerifyAsync_DecryptSignedAndEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.Stream.cs
@@ -118,7 +118,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public async Task DecryptAsync_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -152,7 +152,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public async Task DecryptAsync_DecryptBinaryEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -187,8 +187,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -221,8 +221,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -256,8 +256,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -294,8 +294,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public async Task DecryptAsync_DecryptBinaryEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -333,7 +333,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -363,7 +363,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
@@ -97,6 +97,37 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Teardown
             testFactory.Teardown();
         }
+        
+        [Theory]
+        [InlineData(KeyType.Generated)]
+        [InlineData(KeyType.Known)]
+        [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
+        public async Task DecryptAsync_DecryptEncryptedMessageWithRawPassPhrase_ShouldDecryptMessage(KeyType keyType)
+        {
+            // Arrange
+            TestFactory testFactory = new TestFactory();
+            await testFactory.ArrangeAsync(keyType, FileType.Known);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, Encoding.UTF8.GetBytes(testFactory.Password), testFactory.SymmetricKey);
+            PGP pgpEncrypt = new PGP(encryptionKeys);
+            PGP pgpDecrypt = new PGP(decryptionKeys);
+
+            // Act
+            string encryptedContent = await pgpEncrypt.EncryptAsync(testFactory.Content);
+            string decryptedContent = await pgpDecrypt.DecryptAsync(encryptedContent);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                encryptedContent.Should().NotBeNullOrEmpty();
+                decryptedContent.Should().NotBeNullOrEmpty();
+                decryptedContent.Should().Be(testFactory.Content);
+            }
+
+            // Teardown
+            testFactory.Teardown();
+        }
 
         [Theory]
         [InlineData(KeyType.Generated)]

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
@@ -21,8 +21,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Symmetric, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(string.Empty, testFactory.SymmetricKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(string.Empty, string.Empty, testFactory.SymmetricKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptAsync.String.cs
@@ -129,7 +129,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public async Task DecryptAsync_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -160,8 +160,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -191,8 +191,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public async Task DecryptAsync_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -226,7 +226,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -256,7 +256,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public async Task DecryptAsync_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public async Task DecryptAsync_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.File.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.File.cs
@@ -112,7 +112,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public void Decrypt_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -143,7 +143,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public void Decrypt_DecryptBinaryEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -175,8 +175,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -206,8 +206,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -238,8 +238,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -272,8 +272,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -307,7 +307,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -334,7 +334,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.File.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.File.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -47,6 +48,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEmptyEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -56,8 +58,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Create empty file
             testFactory.ContentFileInfo.Create().Close();
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -81,13 +83,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptBinaryEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -115,8 +118,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -146,8 +149,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -178,8 +181,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -209,8 +212,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -241,8 +244,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -275,8 +278,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -309,8 +312,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Null
@@ -336,8 +339,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Safer
@@ -362,6 +365,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedWithMultipleKeys_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -376,7 +380,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -406,6 +410,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptSignedAndEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -415,7 +420,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
             EncryptionKeys encryptionAndSigningKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory2.PrivateKeyFileInfo, testFactory2.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncryptAndSign = new PGP(encryptionAndSigningKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -439,13 +444,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptUnencryptedMessage_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
 
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             File.WriteAllText(testFactory.ContentFileInfo.FullName, testFactory.Content);
 
@@ -467,6 +473,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange
@@ -475,7 +482,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -512,7 +519,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 password
                 );
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, password);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -537,6 +544,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessage_ShouldDecryptAndVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -572,6 +580,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.Stream.cs
@@ -18,13 +18,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -51,13 +52,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEmptyEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -84,13 +86,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptBinaryEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -121,8 +124,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -155,8 +158,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -190,8 +193,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -224,8 +227,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -259,8 +262,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -297,8 +300,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -335,8 +338,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Null
@@ -364,8 +367,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Safer
@@ -392,6 +395,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedWithMultipleKeys_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -406,7 +410,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -441,6 +445,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptSignedAndEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -450,7 +455,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
             EncryptionKeys encryptionAndSigningKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory2.PrivateKeyStream, testFactory2.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncryptAndSign = new PGP(encryptionAndSigningKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -477,13 +482,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptUnencryptedMessage_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
 
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             File.WriteAllText(testFactory.ContentFileInfo.FullName, testFactory.Content);
 
@@ -507,6 +513,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange
@@ -515,7 +522,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -543,6 +550,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessage_ShouldDecryptAndVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -581,6 +589,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.Stream.cs
@@ -118,7 +118,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public void Decrypt_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -152,7 +152,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public void Decrypt_DecryptBinaryEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -187,8 +187,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -221,8 +221,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -256,8 +256,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -294,8 +294,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public void Decrypt_DecryptBinaryEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -333,7 +333,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -362,7 +362,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.String.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.String.cs
@@ -18,13 +18,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -50,8 +51,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.GeneratedLarge);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -75,13 +76,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEmptyEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -107,8 +109,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = compressionAlgorithmTag
@@ -138,8 +140,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -169,8 +171,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = symmetricKeyAlgorithmTag
@@ -203,8 +205,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Null
@@ -233,8 +235,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 SymmetricKeyAlgorithm = SymmetricKeyAlgorithmTag.Safer
@@ -261,6 +263,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedWithMultipleKeys_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -275,7 +278,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -305,6 +308,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptSignedAndEncryptedMessage_ShouldDecryptMessage(KeyType keyType)
         {
             // Arrange
@@ -314,7 +318,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
             EncryptionKeys encryptionAndSigningKeys = new EncryptionKeys(testFactory.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncryptAndSign = new PGP(encryptionAndSigningKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -338,13 +342,14 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptUnencryptedMessage_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
 
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
             // Act
@@ -367,6 +372,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Decrypt_DecryptEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange
@@ -375,7 +381,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -402,6 +408,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessage_ShouldDecryptAndVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -437,6 +444,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptAndVerify_DecryptSignedAndEncryptedMessageWithWrongKey_ShouldThrowException(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.String.cs
+++ b/PgpCore.Tests/UnitTests/Decrypt/DecryptSync.String.cs
@@ -103,7 +103,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetCompressionAlgorithimTags))]
+        [MemberData(nameof(GetCompressionAlgorithmTags))]
         public void Decrypt_DecryptEncryptedCompressedMessage_ShouldDecryptMessage(CompressionAlgorithmTag compressionAlgorithmTag)
         {
             // Arrange
@@ -134,8 +134,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetHashAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithim_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
+        [MemberData(nameof(GetHashAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedHashAlgorithm_ShouldDecryptMessage(HashAlgorithmTag hashAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -165,8 +165,8 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Theory]
-        [MemberData(nameof(GetSymmetricAlgorithimTags))]
-        public void Decrypt_DecryptEncryptedWithSpecifiedSymetricKeyAlgorithim_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
+        [MemberData(nameof(GetSymmetricAlgorithmTags))]
+        public void Decrypt_DecryptEncryptedWithSpecifiedSymmetricKeyAlgorithm_ShouldDecryptMessage(SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -200,7 +200,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithNullSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithNullSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
@@ -230,7 +230,7 @@ namespace PgpCore.Tests.UnitTests.Decrypt
         }
 
         [Fact]
-        public void Decrypt_DecryptEncryptedWithSaferSymetricKeyAlgorithim_ShouldThrowException()
+        public void Decrypt_DecryptEncryptedWithSaferSymmetricKeyAlgorithm_ShouldThrowException()
         {
             // Arrange
             TestFactory testFactory = new TestFactory();

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.File.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.File.cs
@@ -16,12 +16,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -50,6 +51,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
@@ -58,7 +60,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
 
             // Create empty file
             testFactory.ContentFileInfo.Create().Close();
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -87,12 +89,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageAsBinary_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -119,12 +122,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -153,12 +157,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -187,12 +192,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -223,12 +229,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -257,12 +264,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -291,6 +299,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -331,6 +340,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageAsBinary_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -368,6 +378,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -407,6 +418,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -446,6 +458,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -487,6 +500,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.Stream.cs
@@ -18,12 +18,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -53,13 +54,14 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -89,12 +91,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageAsBinary_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -122,12 +125,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -157,12 +161,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -192,12 +197,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -229,12 +235,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -264,12 +271,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -299,6 +307,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -340,6 +349,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageAsBinary_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -378,6 +388,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -418,6 +429,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -458,6 +470,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -500,6 +513,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptAsync.String.cs
@@ -18,12 +18,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -52,12 +53,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -86,12 +88,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -120,12 +123,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -154,12 +158,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -190,12 +195,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -224,12 +230,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAsync_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -258,6 +265,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -298,6 +306,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -337,6 +346,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -376,6 +386,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -417,6 +428,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task EncryptAndSignAsync_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.File.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.File.cs
@@ -16,12 +16,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -50,6 +51,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
@@ -59,7 +61,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
             // Create empty file
             testFactory.ContentFileInfo.Create().Close();
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -88,12 +90,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageAsBinary_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -120,12 +123,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -154,12 +158,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -188,12 +193,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -224,12 +230,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -258,12 +265,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -292,6 +300,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -332,6 +341,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageAsBinary_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -369,6 +379,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -408,6 +419,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -447,6 +459,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -488,6 +501,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.Stream.cs
@@ -18,12 +18,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -53,12 +54,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -88,12 +90,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageAsBinary_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -121,12 +124,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -156,12 +160,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -191,12 +196,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -228,12 +234,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -263,12 +270,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -298,6 +306,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -339,6 +348,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageAsBinary_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -377,6 +387,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -417,6 +428,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -457,6 +469,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -499,6 +512,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.String.cs
+++ b/PgpCore.Tests/UnitTests/Encrypt/EncryptSync.String.cs
@@ -18,12 +18,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -52,12 +53,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptEmptyMessageWithDefaultProperties_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -86,12 +88,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithoutIntegrityCheck_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -120,12 +123,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithName_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -154,12 +158,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithHeaders_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -190,12 +195,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageAndOverwriteVersionHeader_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -224,12 +230,13 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Encrypt_EncryptMessageWithOldFormat_ShouldEncryptMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act
@@ -258,6 +265,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithDefaultProperties_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -298,6 +306,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithoutIntegrityCheck_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -337,6 +346,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithName_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -376,6 +386,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithHeaders_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange
@@ -417,6 +428,7 @@ namespace PgpCore.Tests.UnitTests.Encrypt
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptAndSign_EncryptAndSignMessageWithOldFormat_ShouldEncryptAndSignMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Recipient/RecipientsSync.File.cs
+++ b/PgpCore.Tests/UnitTests/Recipient/RecipientsSync.File.cs
@@ -22,7 +22,7 @@ namespace PgpCore.Tests.UnitTests.Recipient
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
 
             // Act

--- a/PgpCore.Tests/UnitTests/Sign/SignAsync.File.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignAsync.File.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -58,13 +59,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageAsBinary_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -97,13 +99,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -138,13 +141,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -181,13 +185,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -222,13 +227,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -251,13 +257,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -280,6 +287,7 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
@@ -288,8 +296,8 @@ namespace PgpCore.Tests.UnitTests.Sign
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";
             File.WriteAllText(testFactory.ContentFileInfo.FullName, utf8Content, Encoding.UTF8);
             
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 

--- a/PgpCore.Tests/UnitTests/Sign/SignAsync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignAsync.Stream.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -60,13 +61,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageAsBinary_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -101,13 +103,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -144,13 +147,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -189,13 +193,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -232,13 +237,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -263,13 +269,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -294,6 +301,7 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
@@ -302,8 +310,8 @@ namespace PgpCore.Tests.UnitTests.Sign
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";
             File.WriteAllText(testFactory.ContentFileInfo.FullName, utf8Content, Encoding.UTF8);
             
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 

--- a/PgpCore.Tests/UnitTests/Sign/SignAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignAsync.String.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -58,13 +59,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -99,13 +101,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -142,13 +145,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task SignAsync_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -183,13 +187,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -212,13 +217,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -241,13 +247,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task ClearSignAsync_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";

--- a/PgpCore.Tests/UnitTests/Sign/SignSync.File.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignSync.File.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -58,13 +59,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageAsBinary_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -97,13 +99,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -138,13 +141,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -181,13 +185,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -222,13 +227,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -251,13 +257,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -280,6 +287,7 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
@@ -288,8 +296,8 @@ namespace PgpCore.Tests.UnitTests.Sign
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";
             File.WriteAllText(testFactory.ContentFileInfo.FullName, utf8Content, Encoding.UTF8);
             
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 

--- a/PgpCore.Tests/UnitTests/Sign/SignSync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignSync.Stream.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -60,13 +61,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageAsBinary_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -101,13 +103,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -144,13 +147,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -189,13 +193,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -232,13 +237,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -263,13 +269,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -294,6 +301,7 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
@@ -302,8 +310,8 @@ namespace PgpCore.Tests.UnitTests.Sign
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";
             File.WriteAllText(testFactory.ContentFileInfo.FullName, utf8Content, Encoding.UTF8);
             
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 

--- a/PgpCore.Tests/UnitTests/Sign/SignSync.String.cs
+++ b/PgpCore.Tests/UnitTests/Sign/SignSync.String.cs
@@ -17,13 +17,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -58,13 +59,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithName_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -99,13 +101,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -142,13 +145,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Sign_SignMessageWithOldFormat_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -183,13 +187,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithDefaultProperties_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -212,13 +217,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithHeaders_ShouldSignMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -241,13 +247,14 @@ namespace PgpCore.Tests.UnitTests.Sign
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSign_SignMessageWithUtf8Characters_ShouldPreserveUtf8(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
             string utf8Content = "Test with UTF-8: š ž č ć đ ñ ü ö ä € ₹ 中文 日本語 한글";

--- a/PgpCore.Tests/UnitTests/TestBase.cs
+++ b/PgpCore.Tests/UnitTests/TestBase.cs
@@ -21,7 +21,7 @@ namespace PgpCore.Tests.UnitTests
         public const string TESTHEADERKEY = "Test Header";
         public const string TESTHEADERVALUE = "Test Value";
 
-        public static IEnumerable<object[]> GetCompressionAlgorithimTags()
+        public static IEnumerable<object[]> GetCompressionAlgorithmTags()
         {
             foreach (CompressionAlgorithmTag compressionAlgorithmTag in TestHelper.GetEnumValues<CompressionAlgorithmTag>())
             {
@@ -29,7 +29,7 @@ namespace PgpCore.Tests.UnitTests
             }
         }
 
-        public static IEnumerable<object[]> GetHashAlgorithimTags()
+        public static IEnumerable<object[]> GetHashAlgorithmTags()
         {
             foreach (HashAlgorithmTag hashAlgorithmTag in TestHelper.GetEnumValues<HashAlgorithmTag>())
             {
@@ -37,7 +37,7 @@ namespace PgpCore.Tests.UnitTests
             }
         }
 
-        public static IEnumerable<object[]> GetSymmetricAlgorithimTags()
+        public static IEnumerable<object[]> GetSymmetricAlgorithmTags()
         {
             foreach (SymmetricKeyAlgorithmTag symmetricKeyAlgorithmTag in TestHelper.GetEnumValues<SymmetricKeyAlgorithmTag>())
             {

--- a/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsAsync.cs
@@ -39,7 +39,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -59,7 +59,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -86,7 +86,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -113,7 +113,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             pgp.HashAlgorithmTag = hashAlgorithmTag;
 
@@ -128,6 +128,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -136,7 +137,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -157,6 +158,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -165,7 +167,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -186,6 +188,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -194,7 +197,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -208,6 +211,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -216,7 +220,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -230,6 +234,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -238,8 +243,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -254,6 +259,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -262,7 +268,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -276,6 +282,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -286,7 +293,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated);
-            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys encryptionKeysVerify = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
             PGP pgpSign = new PGP(encryptionKeysSign);
             PGP pgpVerify = new PGP(encryptionKeysVerify);
@@ -303,6 +310,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -335,6 +343,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -343,7 +352,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -357,6 +366,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -374,7 +384,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -389,6 +399,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -397,8 +408,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -416,6 +427,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -424,8 +436,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip,
@@ -452,8 +464,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             pgpEncrypt.HashAlgorithmTag = hashAlgorithmTag;
@@ -481,7 +493,7 @@ namespace PgpCore.Tests
 
         ////    // Act
         ////    pgp.EncryptFile(testFactory.ContentFileInfo, testFactory.EncryptedContentFileInfo, testFactory.PublicKeyFilePath);
-        ////    pgp.DecryptFile(testFactory.EncryptedContentFileInfo, testFactory.DecryptedContentFileInfo, testFactory.PrivateKeyFilePath, testFactory.Password);
+        ////    pgp.DecryptFile(testFactory.EncryptedContentFileInfo, testFactory.DecryptedContentFileInfo, testFactory.PrivateKeyFilePath, testFactory.Password, testFactory.SymmetricKey);
 
         ////    // Assert
         ////    Assert.True(testFactory.EncryptedContentFileInfo.Exists);
@@ -492,6 +504,7 @@ namespace PgpCore.Tests
         ////}
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -509,7 +522,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -532,6 +545,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -540,7 +554,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -557,6 +571,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -574,7 +589,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -597,6 +612,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -607,8 +623,8 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -630,6 +646,7 @@ namespace PgpCore.Tests
 
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -641,8 +658,8 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -663,6 +680,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -671,7 +689,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -689,6 +707,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -697,7 +716,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys)
             {
@@ -718,6 +737,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -729,7 +749,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -749,6 +769,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -757,7 +778,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -773,6 +794,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -784,7 +806,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -803,6 +825,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -811,7 +834,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -833,6 +856,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -844,7 +868,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -868,7 +892,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.GeneratedMedium);
             
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             using (Stream inputFileStream = testFactory.ContentStream)
             using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
@@ -892,6 +916,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -900,7 +925,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -919,6 +944,7 @@ namespace PgpCore.Tests
 
         #region Stream
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -927,7 +953,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -949,7 +975,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -979,7 +1005,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1003,6 +1029,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1011,7 +1038,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1027,6 +1054,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1035,7 +1063,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1059,6 +1087,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1067,7 +1096,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1091,6 +1120,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1099,7 +1129,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1115,6 +1145,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1123,8 +1154,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpVerify = new PGP(verificationKeys);
             bool verified = false;
@@ -1146,6 +1177,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1154,7 +1186,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             bool verified = false;
 
@@ -1174,6 +1206,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1184,7 +1217,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated);
-            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys encryptionKeysVerify = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
             PGP pgpSign = new PGP(encryptionKeysSign);
             PGP pgpVerify = new PGP(encryptionKeysVerify);
@@ -1207,6 +1240,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1215,8 +1249,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpVerify = new PGP(verificationKeys);
             bool verified = false;
@@ -1242,6 +1276,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1259,7 +1294,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -1276,6 +1311,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1284,7 +1320,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1300,6 +1336,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1317,7 +1354,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -1334,6 +1371,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1342,8 +1380,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -1366,6 +1404,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1374,8 +1413,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip,
@@ -1401,6 +1440,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1418,7 +1458,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1449,6 +1489,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1457,7 +1498,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1482,6 +1523,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1499,7 +1541,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1536,6 +1578,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1544,7 +1587,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1566,6 +1609,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1576,7 +1620,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyStream);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1601,6 +1645,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1609,7 +1654,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             bool verified = false;
 
@@ -1630,6 +1675,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1641,7 +1687,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyStream, testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1671,7 +1717,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.GeneratedMedium);
             
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             using (Stream inputFileStream = testFactory.ContentStream)
             using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
@@ -1703,7 +1749,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1723,7 +1769,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1748,7 +1794,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1773,7 +1819,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             pgp.HashAlgorithmTag = hashAlgorithmTag;
 
@@ -1788,6 +1834,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1796,7 +1843,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1810,6 +1857,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1818,7 +1866,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1838,6 +1886,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1846,7 +1895,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1866,6 +1915,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1874,7 +1924,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1888,6 +1938,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1896,7 +1947,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1911,6 +1962,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1922,7 +1974,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1941,6 +1993,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1949,7 +2002,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1965,6 +2018,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -1976,7 +2030,7 @@ namespace PgpCore.Tests
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1996,6 +2050,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2029,6 +2084,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2037,7 +2093,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2051,6 +2107,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2068,7 +2125,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2083,6 +2140,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2091,8 +2149,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -2110,6 +2168,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2118,8 +2177,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2146,7 +2205,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -2166,6 +2225,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2183,7 +2243,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2206,6 +2266,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2214,7 +2275,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2231,6 +2292,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2248,7 +2310,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2271,6 +2333,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2281,7 +2344,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2299,6 +2362,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2309,8 +2373,8 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -2330,6 +2394,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2338,7 +2403,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2355,6 +2420,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2363,7 +2429,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip,
@@ -2383,6 +2449,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2393,7 +2460,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2413,6 +2480,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2421,7 +2489,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2437,6 +2505,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2447,7 +2516,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2466,6 +2535,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2474,7 +2544,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2490,6 +2560,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2498,7 +2569,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2514,6 +2585,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2524,7 +2596,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2543,6 +2615,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2553,7 +2626,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2573,6 +2646,7 @@ namespace PgpCore.Tests
         }
 
         [Theory]
+        [InlineData(KeyType.Symmetric)]
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
@@ -2582,7 +2656,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             using (Stream inputFileStream = testFactory.ContentStream)
             using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
@@ -2614,7 +2688,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)
@@ -2650,7 +2724,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2689,7 +2763,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)
@@ -2725,7 +2799,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2764,7 +2838,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2803,7 +2877,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)

--- a/PgpCore.Tests/UnitTests/UnitTestsSync.cs
+++ b/PgpCore.Tests/UnitTests/UnitTestsSync.cs
@@ -23,7 +23,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -43,7 +43,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -70,7 +70,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -97,7 +97,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             pgp.HashAlgorithmTag = hashAlgorithmTag;
 
@@ -115,12 +115,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignFile_CreateSignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -137,12 +138,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignFile_CreateSignedFileWithCommentHeader_ShouldAddCommentHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -166,12 +168,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignFile_CreateSignedFileWithVersionHeader_ShouldOverwriteDefaultHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -195,12 +198,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignFile_CreateClearSignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -217,13 +221,14 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndVerifyFile_CreateClearSignedFileAndVerify(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -241,6 +246,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndDoNotVerifyFile_CreateClearSignedFileAndDoNotVerify(KeyType keyType)
         {
             // Arrange
@@ -248,7 +254,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated);
-            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeysSign = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys encryptionKeysVerify = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
             PGP pgpSign = new PGP(encryptionKeysSign);
             PGP pgpVerify = new PGP(encryptionKeysVerify);
@@ -268,6 +274,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptFile_CreateEncryptedFileWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -300,12 +307,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptFileAndSign_CreateEncryptedAndSignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -322,6 +330,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptFileAndSign_CreateEncryptedAndSignedFileWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -336,7 +345,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -354,13 +363,14 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFile_DecryptEncryptedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -384,8 +394,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
             pgpEncrypt.HashAlgorithmTag = hashAlgorithmTag;
@@ -413,7 +423,7 @@ namespace PgpCore.Tests
 
         ////    // Act
         ////    pgp.EncryptFile(testFactory.ContentFileInfo, testFactory.EncryptedContentFileInfo, testFactory.PublicKeyFileInfo);
-        ////    pgp.DecryptFile(testFactory.EncryptedContentFileInfo, testFactory.DecryptedContentFileInfo, testFactory.PrivateKeyFilePath, testFactory.Password);
+        ////    pgp.DecryptFile(testFactory.EncryptedContentFileInfo, testFactory.DecryptedContentFileInfo, testFactory.PrivateKeyFilePath, testFactory.Password, testFactory.SymmetricKey);
 
         ////    // Assert
         ////    Assert.True(testFactory.EncryptedContentFileInfo.Exists);
@@ -427,6 +437,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFile_DecryptEncryptedFileWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -441,7 +452,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -467,12 +478,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFile_DecryptSignedAndEncryptedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -492,6 +504,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFile_DecryptSignedAndEncryptedFileWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -506,7 +519,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyFileInfo
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -532,6 +545,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFileAndVerify_DecryptUnsignedFile(KeyType keyType)
         {
             // Arrange
@@ -539,8 +553,8 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -565,6 +579,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFileAndVerify_DecryptWithWrongKey(KeyType keyType)
         {
             // Arrange
@@ -573,8 +588,8 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -598,12 +613,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFileAndVerify_DecryptSignedAndEncryptedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -624,12 +640,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFileAndVerify_DecryptSignedAndEncryptedAndCompressedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys)
             {
@@ -653,6 +670,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptFileAndVerify_DecryptSignedAndEncryptedFileDifferentKeys(KeyType keyType)
         {
             // Arrange
@@ -661,7 +679,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory2.PrivateKeyFileInfo, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -684,12 +702,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyFile_VerifyEncryptedAndSignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -708,6 +727,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyFile_DoNotVerifyEncryptedAndSignedFile(KeyType keyType)
         {
             // Arrange
@@ -716,7 +736,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -738,12 +758,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyFile_VerifySignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -762,6 +783,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyFile_DoNotVerifySignedFile(KeyType keyType)
         {
             // Arrange
@@ -770,7 +792,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyFileInfo);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -793,12 +815,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptStream_CreateEncryptedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -820,7 +843,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -850,7 +873,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -877,12 +900,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignStream_CreateSignedFile(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -901,12 +925,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignStream_CreateSignedStreamWithCommentHeader_ShouldAddCommentHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -933,12 +958,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignStream_CreateSignedStreamWithVersionHeader_ShouldOverwriteDefaultHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -965,6 +991,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptStream_CreateEncryptedStreamWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -979,7 +1006,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -999,12 +1026,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptStreamAndSign_CreateEncryptedAndSignedStream(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1023,6 +1051,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptStreamAndSign_CreateEncryptedAndSignedStreamWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1037,7 +1066,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgp = new PGP(encryptionKeys);
 
@@ -1057,13 +1086,14 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptStream_DecryptEncryptedStream(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -1091,8 +1121,8 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
 
@@ -1125,6 +1155,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptStream_DecryptEncryptedStreamWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1139,7 +1170,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1173,12 +1204,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptStream_DecryptSignedAndEncryptedStream(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1206,6 +1238,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptStream_DecryptSignedAndEncryptedStreamWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1220,7 +1253,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKeyStream
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1260,12 +1293,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_VerifyEncryptedAndSignedStream(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1292,7 +1326,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1323,6 +1357,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_DoNotVerifyEncryptedAndSignedStream(KeyType keyType)
         {
             // Arrange
@@ -1330,7 +1365,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyStream);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1358,12 +1393,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_VerifySignedStream(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             bool verified = false;
 
@@ -1387,6 +1423,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_DoNotVerifySignedStream(KeyType keyType)
         {
             // Arrange
@@ -1395,7 +1432,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKeyStream, testFactory2.PrivateKeyStream, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1422,12 +1459,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Recipients_GetStreamRecipient(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1449,6 +1487,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Recipients_GetStreamRecipients(KeyType keyType)
         {
             // Arrange
@@ -1494,7 +1533,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.GeneratedMedium);
             
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             using (Stream inputFileStream = testFactory.ContentStream)
             using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
@@ -1527,7 +1566,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1547,7 +1586,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1572,7 +1611,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1597,7 +1636,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             pgp.HashAlgorithmTag = hashAlgorithmTag;
 
@@ -1615,12 +1654,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignArmoredString_CreateSignedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1637,12 +1677,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignArmoredString_CreateSignedStringWithCommentHeader_ShouldAddCommentHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1665,12 +1706,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void SignArmoredString_CreateSignedStringWithVersionHeader_ShouldOverwriteDefaultHeader(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             Dictionary<string, string> headers = new Dictionary<string, string>()
             {
@@ -1693,12 +1735,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignArmoredString_CreateClearSignedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1715,12 +1758,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndVerifyArmoredString_CreateClearSignedStringAndVerify(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1737,6 +1781,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndDoNotVerifyArmoredString_CreateClearSignedStringAndDoNotVerify(KeyType keyType)
         {
             // Arrange
@@ -1745,7 +1790,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1766,12 +1811,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndVerifyArmoredString_CreateClearSignedStringAndVerifyAndRead(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1790,6 +1836,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void ClearSignAndDoNotVerifyArmoredString_CreateClearSignedStringAndDoNotVerifyAndRead(KeyType keyType)
         {
             // Arrange
@@ -1798,7 +1845,7 @@ namespace PgpCore.Tests
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1821,6 +1868,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptArmoredString_CreateEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1854,12 +1902,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptArmoredStringAndSign_CreateEncryptedAndSignedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1876,6 +1925,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void EncryptArmoredStringAndSign_CreateEncryptedAndSignedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1890,7 +1940,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1908,12 +1958,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredString_DecryptEncryptedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -1936,7 +1987,7 @@ namespace PgpCore.Tests
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Known, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 HashAlgorithmTag = hashAlgorithmTag
@@ -1959,6 +2010,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredString_DecryptEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -1973,7 +2025,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -1999,12 +2051,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredString_DecryptSignedAndEncryptedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2024,6 +2077,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredString_DecryptSignedAndEncryptedStringWithMultipleKeys(KeyType keyType)
         {
             // Arrange
@@ -2038,7 +2092,7 @@ namespace PgpCore.Tests
                 testFactory2.PublicKey
             };
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(keys, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2064,6 +2118,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredStringAndVerify_DecryptUnsignedString(KeyType keyType)
         {
             // Arrange
@@ -2071,7 +2126,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2092,6 +2147,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredStringAndVerify_DecryptWithWrongKey(KeyType keyType)
         {
             // Arrange
@@ -2099,8 +2155,8 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
-            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
             PGP pgpDecrypt = new PGP(decryptionKeys);
@@ -2123,12 +2179,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredStringAndVerify_DecryptSignedAndEncryptedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2148,12 +2205,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredStringAndVerify_DecryptSignedAndEncryptedAndCompressedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip,
@@ -2176,6 +2234,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void DecryptArmoredStringAndVerify_DecryptSignedAndEncryptedStringDifferentKeys(KeyType keyType)
         {
             // Arrange
@@ -2183,7 +2242,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2206,12 +2265,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_VerifyEncryptedAndSignedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2230,6 +2290,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_DoNotVerifyEncryptedAndSignedString(KeyType keyType)
         {
             // Arrange
@@ -2237,7 +2298,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey, testFactory2.PrivateKey, testFactory2.Password);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2259,12 +2320,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_VerifySignedString(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2283,12 +2345,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyAndRead_VerifySignedStringAndReturnContents(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2308,6 +2371,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Verify_DoNotVerifySignedString(KeyType keyType)
         {
             // Arrange
@@ -2315,7 +2379,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2337,6 +2401,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyAndRead_DoNotVerifySignedString(KeyType keyType)
         {
             // Arrange
@@ -2344,7 +2409,7 @@ namespace PgpCore.Tests
             TestFactory testFactory2 = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             testFactory2.Arrange(KeyType.Generated, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             EncryptionKeys decryptionKeys = new EncryptionKeys(testFactory2.PublicKey);
 
             PGP pgpEncrypt = new PGP(encryptionKeys);
@@ -2367,12 +2432,13 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Recipients_GetStringRecipient(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             // Act
@@ -2391,6 +2457,7 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void Recipients_GetStringRecipients(KeyType keyType)
         {
             // Arrange
@@ -2424,13 +2491,14 @@ namespace PgpCore.Tests
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public void VerifyAndReadSignedArmoredString_WhenEncryptedAndNotSigned_ShouldThrowException(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(keyType, FileType.Known);
             
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
             using (Stream inputFileStream = testFactory.ContentStream)
             using (Stream outputFileStream = testFactory.EncryptedContentFileInfo.Create())
@@ -2462,7 +2530,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)
@@ -2498,7 +2566,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2537,7 +2605,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)
@@ -2573,7 +2641,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2612,7 +2680,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys)
             {
                 CompressionAlgorithm = CompressionAlgorithmTag.Zip
@@ -2651,7 +2719,7 @@ namespace PgpCore.Tests
             TestFactory testFactory = new TestFactory();
             testFactory.Arrange(KeyType.Generated, FileType.Known);
 
-            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password);
+            EncryptionKeys encryptionKeys = new EncryptionKeys(testFactory.PublicKey, testFactory.PrivateKey, testFactory.Password, testFactory.SymmetricKey);
             PGP pgp = new PGP(encryptionKeys);
 
             using (Stream inputFileStream = testFactory.ContentStream)

--- a/PgpCore.Tests/UnitTests/Verify/VerifyAsync.File.cs
+++ b/PgpCore.Tests/UnitTests/Verify/VerifyAsync.File.cs
@@ -13,13 +13,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -41,13 +42,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifyAndReadSignedMessage_ShouldVerifyAndReadMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -70,6 +72,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -102,13 +105,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -130,13 +134,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyAndReadClearSignedMessage_ShouldVerifyAndReadMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -160,6 +165,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -192,6 +198,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedModifiedMessage_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore.Tests/UnitTests/Verify/VerifyAsync.Stream.cs
+++ b/PgpCore.Tests/UnitTests/Verify/VerifyAsync.Stream.cs
@@ -13,13 +13,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -42,13 +43,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifyAndReadSignedMessage_ShouldVerifyAndReadMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -72,6 +74,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -80,8 +83,8 @@ namespace PgpCore.Tests.UnitTests.Verify
 
             await testFactory1.ArrangeAsync(keyType, FileType.Known);
             await testFactory2.ArrangeAsync(KeyType.Generated, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory1.PrivateKeyStream, testFactory1.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory2.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory1.PrivateKeyStream, testFactory1.Password, testFactory1.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory2.PublicKeyStream, testFactory2.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -105,13 +108,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -134,13 +138,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyAndReadClearSignedMessage_ShouldVerifyAndReadMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -165,6 +170,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -198,14 +204,15 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedModifiedMessage_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
 
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyStream, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyStream, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 

--- a/PgpCore.Tests/UnitTests/Verify/VerifyAsync.String.cs
+++ b/PgpCore.Tests/UnitTests/Verify/VerifyAsync.String.cs
@@ -13,13 +13,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -41,6 +42,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyAsync_VerifySignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -73,13 +75,14 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessage_ShouldVerifyMessage(KeyType keyType)
         {
             // Arrange
             TestFactory testFactory = new TestFactory();
             await testFactory.ArrangeAsync(keyType, FileType.Known);
-            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password);
-            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo);
+            EncryptionKeys signingKeys = new EncryptionKeys(testFactory.PrivateKeyFileInfo, testFactory.Password, testFactory.SymmetricKey);
+            EncryptionKeys verificationKeys = new EncryptionKeys(testFactory.PublicKeyFileInfo, testFactory.SymmetricKey);
             PGP pgpSign = new PGP(signingKeys);
             PGP pgpVerify = new PGP(verificationKeys);
 
@@ -101,6 +104,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedMessageWithWrongKey_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange
@@ -133,6 +137,7 @@ namespace PgpCore.Tests.UnitTests.Verify
         [InlineData(KeyType.Generated)]
         [InlineData(KeyType.Known)]
         [InlineData(KeyType.KnownGpg)]
+        [InlineData(KeyType.Symmetric)]
         public async Task VerifyClearAsync_VerifyClearSignedModifiedMessage_ShouldNotVerifyMessage(KeyType keyType)
         {
             // Arrange

--- a/PgpCore/Abstractions/IEncryptionKeys.cs
+++ b/PgpCore/Abstractions/IEncryptionKeys.cs
@@ -26,6 +26,7 @@ namespace PgpCore.Abstractions
         PgpPrivateKey PrivateKey { get; }
         PgpSecretKey SecretKey { get; }
         PgpSecretKeyRingBundle SecretKeys { get; }
+        byte[] SymmetricKey { get; }
 
         PgpPrivateKey FindSecretKey(long keyId);
     }

--- a/PgpCore/Abstractions/IPGP.KeyAsync.cs
+++ b/PgpCore/Abstractions/IPGP.KeyAsync.cs
@@ -19,7 +19,7 @@ namespace PgpCore.Abstractions
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null);
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null);
 
         Task GenerateKeyAsync(
             Stream publicKeyStream,
@@ -34,6 +34,6 @@ namespace PgpCore.Abstractions
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null);
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null);
     }
 }

--- a/PgpCore/Abstractions/IPGP.KeySync.cs
+++ b/PgpCore/Abstractions/IPGP.KeySync.cs
@@ -21,7 +21,7 @@ namespace PgpCore.Abstractions
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null);
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null);
 
         void GenerateKey(
             Stream publicKeyStream,
@@ -36,6 +36,6 @@ namespace PgpCore.Abstractions
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null);
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null);
     }
 }

--- a/PgpCore/Helpers/Utilities.cs
+++ b/PgpCore/Helpers/Utilities.cs
@@ -594,10 +594,8 @@ namespace PgpCore
 
 			var secretKeys = keyRings.SelectMany(ring => ring.GetSecretKeys().Cast<PgpSecretKey>())
 				.OrderByDescending(GetSigningScore).ToArray();
-			
-			if(!secretKeys.Any())
-				throw new ArgumentException("Could not find any signing keys in keyring");
-			return secretKeys.First();
+
+			return secretKeys.FirstOrDefault();
 		}
 
 		/// <summary>

--- a/PgpCore/Models/EncryptionKeys.cs
+++ b/PgpCore/Models/EncryptionKeys.cs
@@ -303,6 +303,30 @@ namespace PgpCore
 			_passPhrase = passPhrase;
 			InitializeKeys(keyRings);
 		}
+		
+		/// <summary>
+		/// Initializes a new instance of the EncryptionKeys class that is to be used for symmetric encryption/decryption exclusively.
+		/// The data is encrypted with the passed <paramref name="symmetricKey"/>.
+		/// </summary>
+		/// <param name="symmetricKey">The key used to encrypt/decrypt the data</param>
+		public EncryptionKeys(byte[] symmetricKey)
+		{
+			if (symmetricKey == null || symmetricKey.Length == 0)
+			{
+				throw new ArgumentException("SymmetricKey");
+			}
+			
+			_symmetricKey = symmetricKey;
+			
+			try
+			{
+				InitializeKeys(Array.Empty<PgpPublicKeyRing>());
+			}
+			catch (Exception ex)
+			{
+				throw new PgpException($"Error initializing keys.", ex);
+			}
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the EncryptionKeys class.

--- a/PgpCore/PGP.DecryptAsync.cs
+++ b/PgpCore/PGP.DecryptAsync.cs
@@ -71,24 +71,44 @@ namespace PgpCore
             {
                 // decrypt
                 PgpPrivateKey privateKey = null;
-                PgpPublicKeyEncryptedData pbe = null;
+                PgpPublicKeyEncryptedData encryptedDataAsymmetric = null;
+                PgpPbeEncryptedData encryptedDataSymmetric = null;
+                
                 if (enc != null)
                 {
-                    foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in enc.GetEncryptedDataObjects())
+                    foreach (PgpEncryptedData encryptedData in enc.GetEncryptedDataObjects())
                     {
-                        privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
-
-                        if (privateKey != null)
+                        if (encryptedData is PgpPublicKeyEncryptedData publicKeyEncryptedData)
                         {
-                            pbe = publicKeyEncryptedData;
-                            break;
+                            privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+                            if (privateKey != null)
+                            {
+                                encryptedDataAsymmetric = publicKeyEncryptedData;
+                                break;
+                            }   
+                        }
+
+                        if (encryptedData is PgpPbeEncryptedData passwordEncryptedData)
+                        {
+                            encryptedDataSymmetric = passwordEncryptedData;
                         }
                     }
 
-                    if (privateKey == null)
-                        throw new ArgumentException("Secret key for message not found.");
+                    Stream clear = null;
 
-                    Stream clear = pbe.GetDataStream(privateKey).DisposeWith(disposables);
+                    if (encryptedDataAsymmetric != null)
+                    {
+                        clear = encryptedDataAsymmetric.GetDataStream(privateKey).DisposeWith(disposables);
+                    }
+                    else if (encryptedDataSymmetric != null && EncryptionKeys.SymmetricKey != null && EncryptionKeys.SymmetricKey.Length > 0)
+                    {
+                        clear = encryptedDataSymmetric.GetDataStreamRaw(EncryptionKeys.SymmetricKey).DisposeWith(disposables);
+                    }
+                    
+                    if (clear == null)
+                        throw new ArgumentException("Secret key for message not found.");
+                    
                     PgpObjectFactory plainFact = new PgpObjectFactory(clear);
 
                     message = plainFact.NextPgpObject();
@@ -124,11 +144,24 @@ namespace PgpCore
                     Stream unc = literalData.GetInputStream();
                     await StreamHelper.PipeAllAsync(unc, outputStream);
 
-                    if (pbe.IsIntegrityProtected())
+                    if (encryptedDataAsymmetric != null)
                     {
-                        if (!pbe.Verify())
+                        if (encryptedDataAsymmetric.IsIntegrityProtected())
                         {
-                            throw new PgpException("Message failed integrity check.");
+                            if (!encryptedDataAsymmetric.Verify())
+                            {
+                                throw new PgpException("Message failed integrity check.");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (encryptedDataSymmetric.IsIntegrityProtected())
+                        {
+                            if (!encryptedDataSymmetric.Verify())
+                            {
+                                throw new PgpException("Message failed integrity check.");
+                            }
                         }
                     }
                 }
@@ -220,25 +253,44 @@ namespace PgpCore
             {
                 // decrypt
                 PgpPrivateKey privateKey = null;
-                PgpPublicKeyEncryptedData pbe = null;
+                PgpPublicKeyEncryptedData encryptedDataAsymmetric = null;
+                PgpPbeEncryptedData encryptedDataSymmetric = null;
+                
                 if (encryptedDataList != null)
                 {
-                    foreach (PgpPublicKeyEncryptedData publicKeyEncryptedData in
-                             encryptedDataList.GetEncryptedDataObjects())
+                    foreach (PgpEncryptedData encryptedData in encryptedDataList.GetEncryptedDataObjects())
                     {
-                        privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
-
-                        if (privateKey != null)
+                        if (encryptedData is PgpPublicKeyEncryptedData publicKeyEncryptedData)
                         {
-                            pbe = publicKeyEncryptedData;
-                            break;
+                            privateKey = EncryptionKeys.FindSecretKey(publicKeyEncryptedData.KeyId);
+
+                            if (privateKey != null)
+                            {
+                                encryptedDataAsymmetric = publicKeyEncryptedData;
+                                break;
+                            }   
+                        }
+
+                        if (encryptedData is PgpPbeEncryptedData passwordEncryptedData)
+                        {
+                            encryptedDataSymmetric = passwordEncryptedData;
                         }
                     }
 
-                    if (privateKey == null)
-                        throw new ArgumentException("Secret key for message not found.");
+                    Stream clear = null;
 
-                    Stream clear = pbe.GetDataStream(privateKey).DisposeWith(disposables);
+                    if (encryptedDataAsymmetric != null)
+                    {
+                        clear = encryptedDataAsymmetric.GetDataStream(privateKey).DisposeWith(disposables);
+                    }
+                    else if (encryptedDataSymmetric != null && EncryptionKeys.SymmetricKey != null && EncryptionKeys.SymmetricKey.Length > 0)
+                    {
+                        clear = encryptedDataSymmetric.GetDataStreamRaw(EncryptionKeys.SymmetricKey).DisposeWith(disposables);
+                    }
+                    
+                    if (clear == null)
+                        throw new ArgumentException("Secret key for message not found.");
+                    
                     PgpObjectFactory plainFact = new PgpObjectFactory(clear);
 
                     message = plainFact.NextPgpObject();
@@ -311,11 +363,24 @@ namespace PgpCore
                     Stream unc = literalData.GetInputStream();
                     await StreamHelper.PipeAllAsync(unc, outputStream);
 
-                    if (pbe.IsIntegrityProtected())
+                    if (encryptedDataAsymmetric != null)
                     {
-                        if (!pbe.Verify())
+                        if (encryptedDataAsymmetric.IsIntegrityProtected())
                         {
-                            throw new PgpException("Message failed integrity check.");
+                            if (!encryptedDataAsymmetric.Verify())
+                            {
+                                throw new PgpException("Message failed integrity check.");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (encryptedDataSymmetric.IsIntegrityProtected())
+                        {
+                            if (!encryptedDataSymmetric.Verify())
+                            {
+                                throw new PgpException("Message failed integrity check.");
+                            }
                         }
                     }
                 }

--- a/PgpCore/PGP.EncryptAsync.cs
+++ b/PgpCore/PGP.EncryptAsync.cs
@@ -90,7 +90,7 @@ namespace PgpCore
 
             if (armor)
             {
-                outputStream = new ArmoredOutputStream(outputStream, headers);
+                outputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader);
             }
 
             PgpEncryptedDataGenerator pk =
@@ -209,7 +209,7 @@ namespace PgpCore
             {
                 if (armor)
                 {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                     {
                         await OutputEncryptedAsync(inputFile, armoredOutputStream, withIntegrityCheck, name, oldFormat);
                     }
@@ -256,7 +256,7 @@ namespace PgpCore
 
             if (armor)
             {
-                using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                 {
                     await OutputEncryptedAsync(inputStream, armoredOutputStream, withIntegrityCheck, name, oldFormat);
                 }

--- a/PgpCore/PGP.EncryptAsync.cs
+++ b/PgpCore/PGP.EncryptAsync.cs
@@ -100,6 +100,11 @@ namespace PgpCore
                 PgpPublicKey publicKey = publicKeyRing.PreferredEncryptionKey ?? publicKeyRing.DefaultEncryptionKey;
                 pk.AddMethod(publicKey);
             }
+            
+            if (EncryptionKeys.SymmetricKey != null && EncryptionKeys.SymmetricKey.Length > 0)
+            {
+                pk.AddMethodRaw(EncryptionKeys.SymmetricKey, HashAlgorithmTag);
+            }
 
             if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
             {

--- a/PgpCore/PGP.EncryptSync.cs
+++ b/PgpCore/PGP.EncryptSync.cs
@@ -100,6 +100,11 @@ namespace PgpCore
                 pk.AddMethod(publicKey);
             }
 
+            if (EncryptionKeys.SymmetricKey != null && EncryptionKeys.SymmetricKey.Length > 0)
+            {
+                pk.AddMethodRaw(EncryptionKeys.SymmetricKey, HashAlgorithmTag);
+            }
+            
             if (CompressionAlgorithm != CompressionAlgorithmTag.Uncompressed)
             {
                 using (Stream @out = pk.Open(outputStream, new byte[1 << 16]))

--- a/PgpCore/PGP.EncryptSync.cs
+++ b/PgpCore/PGP.EncryptSync.cs
@@ -88,7 +88,7 @@ namespace PgpCore
 
             if (armor)
             {
-                outputStream = new ArmoredOutputStream(outputStream, headers);
+                outputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader);
             }
 
             PgpEncryptedDataGenerator pk =
@@ -207,7 +207,7 @@ namespace PgpCore
             {
                 if (armor)
                 {
-                    using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                    using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                     {
                         OutputEncrypted(inputFile, armoredOutputStream, withIntegrityCheck, name, oldFormat);
                     }
@@ -253,7 +253,7 @@ namespace PgpCore
 
             if (armor)
             {
-                using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                using (var armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                 {
                     OutputEncrypted(inputStream, armoredOutputStream, withIntegrityCheck, name, oldFormat);
                 }

--- a/PgpCore/PGP.KeyAsync.cs
+++ b/PgpCore/PGP.KeyAsync.cs
@@ -23,11 +23,11 @@ namespace PgpCore
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null)
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null)
                 {
                     await Task.Run(() => GenerateKey(publicKeyFileInfo, privateKeyFileInfo, username, password, strength,
                         certainty, armor, emitVersion, keyExpirationInSeconds, signatureExpirationInSeconds,
-                        preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymetricKeyAlgorithms));
+                        preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymmetricKeyAlgorithms));
                 }
 
         public async Task GenerateKeyAsync(
@@ -43,11 +43,11 @@ namespace PgpCore
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null)
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null)
         {
             await Task.Run(() => GenerateKey(publicKeyStream, privateKeyStream, username, password, strength,
                 certainty, armor, emitVersion, keyExpirationInSeconds, signatureExpirationInSeconds,
-                preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymetricKeyAlgorithms));
+                preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymmetricKeyAlgorithms));
         }
     }
 }

--- a/PgpCore/PGP.KeySync.cs
+++ b/PgpCore/PGP.KeySync.cs
@@ -27,7 +27,7 @@ namespace PgpCore
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null)
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null)
         {
             if (publicKeyFileInfo == null)
                 throw new ArgumentException("PublicKeyFileInfo");
@@ -38,7 +38,7 @@ namespace PgpCore
             using (Stream pris = privateKeyFileInfo.Create())
                 GenerateKey(pubs, pris, username, password, strength, certainty, armor, emitVersion,
                     keyExpirationInSeconds, signatureExpirationInSeconds,
-                    preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymetricKeyAlgorithms);
+                    preferredCompressionAlgorithms, preferredHashAlgorithmTags, preferredSymmetricKeyAlgorithms);
         }
 
         public void GenerateKey(
@@ -54,7 +54,7 @@ namespace PgpCore
             long signatureExpirationInSeconds = 0,
             CompressionAlgorithmTag[] preferredCompressionAlgorithms = null,
             HashAlgorithmTag[] preferredHashAlgorithmTags = null,
-            SymmetricKeyAlgorithmTag[] preferredSymetricKeyAlgorithms = null)
+            SymmetricKeyAlgorithmTag[] preferredSymmetricKeyAlgorithms = null)
         {
             username = username ?? string.Empty;
             password = password ?? string.Empty;
@@ -84,7 +84,7 @@ namespace PgpCore
                     HashAlgorithmTag, HashAlgorithmTag.Sha1
                 });
 
-            preferredSymetricKeyAlgorithms = preferredSymetricKeyAlgorithms ??
+            preferredSymmetricKeyAlgorithms = preferredSymmetricKeyAlgorithms ??
                 (SymmetricKeyAlgorithm == SymmetricKeyAlgorithmTag.TripleDes ?
                 new[]
                 {
@@ -105,7 +105,7 @@ namespace PgpCore
             signHashGen.SetKeyFlags(false, PgpKeyFlags.CanCertify | PgpKeyFlags.CanEncryptCommunications | PgpKeyFlags.CanEncryptStorage | PgpKeyFlags.CanSign);
             signHashGen.SetPreferredCompressionAlgorithms(false, Array.ConvertAll(preferredCompressionAlgorithms, item => (int)item));
             signHashGen.SetPreferredHashAlgorithms(false, Array.ConvertAll(preferredHashAlgorithmTags, item => (int)item));
-            signHashGen.SetPreferredSymmetricAlgorithms(false, Array.ConvertAll(preferredSymetricKeyAlgorithms, item => (int)item));
+            signHashGen.SetPreferredSymmetricAlgorithms(false, Array.ConvertAll(preferredSymmetricKeyAlgorithms, item => (int)item));
             signHashGen.SetFeature(false, Features.FEATURE_MODIFICATION_DETECTION);
             signHashGen.SetKeyExpirationTime(false, keyExpirationInSeconds);
             signHashGen.SetSignatureExpirationTime(false, signatureExpirationInSeconds);

--- a/PgpCore/PGP.SignAsync.cs
+++ b/PgpCore/PGP.SignAsync.cs
@@ -48,7 +48,7 @@ namespace PgpCore
             {
                 if (armor)
                 {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                     {
                         await OutputSignedAsync(inputFile, armoredOutputStream, name, oldFormat);
                     }
@@ -92,7 +92,7 @@ namespace PgpCore
 
             if (armor)
             {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                 {
                     await OutputSignedAsync(inputStream, armoredOutputStream, name, oldFormat);
                 }

--- a/PgpCore/PGP.SignSync.cs
+++ b/PgpCore/PGP.SignSync.cs
@@ -48,7 +48,7 @@ namespace PgpCore
             {
                 if (armor)
                 {
-                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                    using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                     {
                         OutputSigned(inputFile, armoredOutputStream, name, oldFormat);
                     }
@@ -92,7 +92,7 @@ namespace PgpCore
 
             if (armor)
             {
-                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+                using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
                 {
                     OutputSigned(inputStream, armoredOutputStream, name, oldFormat);
                 }

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -379,6 +379,11 @@ namespace PgpCore
 				PgpPublicKey publicKey = publicKeyRing.PreferredEncryptionKey ?? publicKeyRing.DefaultEncryptionKey;
 				encryptedDataGenerator.AddMethod(publicKey);
 			}
+			
+			if (EncryptionKeys.SymmetricKey != null && EncryptionKeys.SymmetricKey.Length > 0)
+			{
+				encryptedDataGenerator.AddMethodRaw(EncryptionKeys.SymmetricKey, HashAlgorithmTag);
+			}
 
 			return encryptedDataGenerator.Open(outputStream, new byte[BufferSize]);
 		}

--- a/PgpCore/PGP.cs
+++ b/PgpCore/PGP.cs
@@ -37,6 +37,8 @@ namespace PgpCore
 
 		public IEncryptionKeys EncryptionKeys { get; private set; }
 
+		public bool AddVersionHeader { get; set; } = true;
+
 		#region Constructor
 
 		public PGP()
@@ -215,7 +217,7 @@ namespace PgpCore
 		private async Task OutputClearSignedAsync(Stream inputStream, Stream outputStream, IDictionary<string, string> headers)
 		{
 			using (StreamReader streamReader = new StreamReader(inputStream))
-			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
 			{
 				PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
 
@@ -265,7 +267,7 @@ namespace PgpCore
 		private void OutputClearSigned(Stream inputStream, Stream outputStream, IDictionary<string, string> headers)
 		{
 			using (StreamReader streamReader = new StreamReader(inputStream))
-			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers))
+			using (ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(outputStream, headers, AddVersionHeader))
 			{
 				PgpSignatureGenerator pgpSignatureGenerator = InitClearSignatureGenerator(armoredOutputStream);
 
@@ -495,7 +497,7 @@ namespace PgpCore
 			ArmoredOutputStream secretOutArmored;
 			if (armor)
 			{
-				secretOutArmored = new ArmoredOutputStream(secretOut);
+				secretOutArmored = new ArmoredOutputStream(secretOut, AddVersionHeader);
 				if (!emitVersion)
 				{
 					secretOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);
@@ -515,7 +517,7 @@ namespace PgpCore
 			ArmoredOutputStream publicOutArmored;
 			if (armor)
 			{
-				publicOutArmored = new ArmoredOutputStream(publicOut);
+				publicOutArmored = new ArmoredOutputStream(publicOut, AddVersionHeader);
 				if (!emitVersion)
 				{
 					publicOutArmored.SetHeader(ArmoredOutputStream.HeaderVersion, null);

--- a/PgpCore/PgpCore.csproj
+++ b/PgpCore/PgpCore.csproj
@@ -10,10 +10,10 @@
     <PackageProjectUrl>https://github.com/mattosaurus/PgpCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mattosaurus/PgpCore</RepositoryUrl>
     <PackageTags>PGP .NET Core</PackageTags>
-    <Version>6.5.4.0</Version>
+    <Version>6.6.0.0</Version>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
-    <FileVersion>6.5.4</FileVersion>
-    <PackageReleaseNotes>v6.5.4 - Fix clearsign encoding</PackageReleaseNotes>
+    <FileVersion>6.6.0</FileVersion>
+    <PackageReleaseNotes>v6.6.0 - Add support for symmetric encryption and decryption</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ string encryptedSignedContent = await pgp.DecryptAndVerifyAsync("String to decry
 ## Settings
 The PGP object contains a variety of settings properties that can be used to determine how files are encrypted.
 ### CompressionAlgorithm
-The compression algorithim to be used on the message. This is applied prior to encryption, either to the message or the signed message.
+The compression algorithm to be used on the message. This is applied prior to encryption, either to the message or the signed message.
 - Uncompressed - **Default**
 - Zip
 - ZLib
@@ -603,7 +603,7 @@ The type of signature to be used for file signing.
 - CertificationRevocation
 - Timestamp
 ### PublicKeyAlgorithm
-The public key encryption algorithim.
+The public key encryption algorithm.
 - RsaGeneral - **Default**
 - RsaEncrypt
 - RsaSign
@@ -620,7 +620,7 @@ Encoding to be used for the output file.
 - Text
 - UTF8
 ### HashAlgorithmTag
-The hash algorithim to be used by the signature.
+The hash algorithm to be used by the signature.
 - MD5
 - Sha1 - **Default**
 - RipeMD160


### PR DESCRIPTION
Thought this was missing in this otherwise awesome codebase, so I gave it a shot :)
Tests still succeed and I've added an additional key type in the test data's KeyType enum, but I also tested it manually using Kleopatra: works on my machine :smiling_face_with_tear: 
Cheers <3